### PR TITLE
GFAL2/mkdir fix (lie to posix-assuming clients about directory operations)

### DIFF
--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -168,12 +168,14 @@ int XrdCephOss::Create(const char *tident, const char *path, mode_t access_mode,
 
 int XrdCephOss::Init(XrdSysLogger *logger, const char* configFn) { return 0; }
 
+//SCS - lie to posix-assuming clients about directories [fixes brittleness in GFAL2]
 int XrdCephOss::Mkdir(const char *path, mode_t mode, int mkpath, XrdOucEnv *envP) {
-  return -ENOTSUP;
+  return 0;
 }
 
+//SCS - lie to posix-assuming clients about directories [fixes brittleness in GFAL2]
 int XrdCephOss::Remdir(const char *path, int Opts, XrdOucEnv *eP) {
-  return -ENOTSUP;
+  return 0;
 }
 
 int XrdCephOss::Rename(const char *from,


### PR DESCRIPTION
This is a minimal pull request to merge in the changes needed to get GFAL2-based clients [like FTS] to work with TPC and other tests. 
It returns "success" on directory creation and deletion operations rather than not implemented, a change which does not break anything as directories do not exist in RADOS at all.