### PR TITLE
Fix  AIO read logic affecting end of file

### DIFF
--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -947,7 +947,7 @@ static void ceph_aio_read_complete(rados_completion_t c, void *arg) {
     XrdSysMutexHelper lock(fr->statsMutex);
     fr->asyncRdCompletionCount++;
   }
-  awa->callback(awa->aiop, rc == 0 ? awa->nbBytes : rc);
+  awa->callback(awa->aiop, rc );
   delete(awa);
 }
 


### PR DESCRIPTION
Fix the logic when doing AIO reads. rc returns the number of bytes read; which would be 0 for end of file, or, less than nbytes if a partial read was required. 
Previously, the number of bytes actually read was always returned except if 0 bytes were read, in which case the requested number of bytes was returned. 
With the patch, the number of bytes actually read (including 0) is always returned into the callback. 
This should stop excess data being returned. There remains a final 0 byte read, but this appears to be ok.