### PR TITLE
Add Buffer support for XrdCeph

### DIFF
--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -52,6 +52,8 @@ add_library(
   XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc  XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh 
   XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
   XrdCeph/XrdCephBuffers/BufferUtils.cc  XrdCeph/XrdCephBuffers/BufferUtils.hh
+  XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.cc  XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.hh
+  XrdCeph/XrdCephBuffers/XrdCephReadVBasic.cc  XrdCeph/XrdCephBuffers/XrdCephReadVBasic.hh
 )
 
 target_link_libraries(

--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -45,7 +45,13 @@ add_library(
   MODULE
   XrdCeph/XrdCephOss.cc       XrdCeph/XrdCephOss.hh
   XrdCeph/XrdCephOssFile.cc   XrdCeph/XrdCephOssFile.hh
-  XrdCeph/XrdCephOssDir.cc    XrdCeph/XrdCephOssDir.hh )
+  XrdCeph/XrdCephOssDir.cc    XrdCeph/XrdCephOssDir.hh 
+  XrdCeph/XrdCephOssBufferedFile.cc   XrdCeph/XrdCephOssBufferedFile.hh
+  XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
+  XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc  XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh 
+  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
+  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
+)
 
 target_link_libraries(
   ${LIB_XRD_CEPH}

--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -47,6 +47,7 @@ add_library(
   XrdCeph/XrdCephOssFile.cc   XrdCeph/XrdCephOssFile.hh
   XrdCeph/XrdCephOssDir.cc    XrdCeph/XrdCephOssDir.hh 
   XrdCeph/XrdCephOssBufferedFile.cc   XrdCeph/XrdCephOssBufferedFile.hh
+  XrdCeph/XrdCephOssReadVFile.cc   XrdCeph/XrdCephOssReadVFile.hh
   XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
   XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc  XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh 
   XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh

--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -51,6 +51,7 @@ add_library(
   XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
   XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc  XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh 
   XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
+  XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.hh
   XrdCeph/XrdCephBuffers/BufferUtils.cc  XrdCeph/XrdCephBuffers/BufferUtils.hh
   XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.cc  XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.hh
   XrdCeph/XrdCephBuffers/XrdCephReadVBasic.cc  XrdCeph/XrdCephBuffers/XrdCephReadVBasic.hh

--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -50,7 +50,7 @@ add_library(
   XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
   XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc  XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh 
   XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
-  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc  XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
+  XrdCeph/XrdCephBuffers/BufferUtils.cc  XrdCeph/XrdCephBuffers/BufferUtils.hh
 )
 
 target_link_libraries(

--- a/src/XrdCeph/XrdCephBuffers/BufferUtils.cc
+++ b/src/XrdCeph/XrdCephBuffers/BufferUtils.cc
@@ -4,6 +4,11 @@
 
 using namespace XrdCephBuffer;
 
+#ifdef CEPHBUFDEBUG
+// to synchronise logging statements 
+  std::mutex cephbuf_iolock;
+#endif 
+
 // ------------------------------------------------------ //
 //         Extent       //
 
@@ -52,10 +57,17 @@ Extent Extent::containedExtent(const Extent &rhs) const
 
 bool Extent::operator<(const Extent &rhs) const
 {
-    return begin() < rhs.begin();
+    // comparison primarily on begin values
+    // use end values if begin values are equal.
+
+    if (begin() > rhs.begin()) return false;
+    if (begin() < rhs.begin()) return true;
+    if (end()   < rhs.end() )  return true;
+    return false; 
 }
 bool Extent::operator==(const Extent &rhs) const
 {
+    // equivalence based only on start and end
     if (begin() != rhs.begin())
         return false;
     if (end() != rhs.end())

--- a/src/XrdCeph/XrdCephBuffers/BufferUtils.cc
+++ b/src/XrdCeph/XrdCephBuffers/BufferUtils.cc
@@ -1,7 +1,149 @@
 
 #include "BufferUtils.hh"
+#include <algorithm> // std::max
 
 using namespace XrdCephBuffer;
+
+// ------------------------------------------------------ //
+//         Extent       //
+
+bool Extent::in_extent(off_t pos) const
+{
+    return ((pos > begin()) && (pos < end()));
+}
+
+bool Extent::isContiguous(const Extent &rhs) const
+{
+    // does the rhs connect directly to the end of the first
+    if (end() != rhs.begin())
+        return false;
+    return true;
+}
+
+bool Extent::allInExtent(off_t pos, size_t len) const
+{
+    // is all the range in this extent
+    if ((pos < begin()) || (pos >= end()))
+        return false;
+
+    if (off_t(pos + len) > end())
+        return false;
+    return true;
+}
+bool Extent::someInExtent(off_t pos, size_t len) const
+{ // is some of the range in this extent
+    if ((off_t(pos + len) < begin()) || (pos >= end()))
+        return false;
+    return true;
+}
+
+Extent Extent::containedExtent(off_t pos, size_t len) const
+{
+    // return the subset of input range that is in this extent
+    off_t subbeg = std::max(begin(), pos);
+    off_t subend = std::min(end(), off_t(pos + len));
+
+    return Extent(subbeg, subend - subbeg);
+}
+Extent Extent::containedExtent(const Extent &rhs) const
+{
+    return containedExtent(rhs.begin(), rhs.len());
+}
+
+bool Extent::operator<(const Extent &rhs) const
+{
+    return begin() < rhs.begin();
+}
+bool Extent::operator==(const Extent &rhs) const
+{
+    if (begin() != rhs.begin())
+        return false;
+    if (end() != rhs.end())
+        return false;
+    return true;
+}
+
+// ------------------------------------------------------ //
+//         ExtentHolder       //
+
+ExtentHolder::ExtentHolder() {}
+
+ExtentHolder::ExtentHolder(size_t elements)
+{
+    m_extents.reserve(elements);
+}
+
+ExtentHolder::ExtentHolder(const ExtentContainer &extents)
+{
+    m_extents.reserve(extents.size());
+    for (ExtentContainer::const_iterator vit = m_extents.cbegin(); vit != m_extents.cend(); ++vit) {
+        push_back(*vit);
+    }
+
+}
+ExtentHolder::~ExtentHolder()
+{
+    m_extents.clear();
+}
+
+void ExtentHolder::push_back(const Extent & in) {
+    if (size()) {
+        m_begin = std::min(m_begin, in.begin());
+        m_end   = std::max(m_end, in.end());
+    } else {
+        m_begin = in.begin();
+        m_end = in.end();
+    }
+    return m_extents.push_back(in);
+}
+
+
+
+Extent ExtentHolder::asExtent() const {
+    // if (!size()) return Extent(0,0);
+    // ExtentContainer se = getSortedExtents();
+    // off_t b = se.front().begin();
+    // off_t e = se.back().end();
+
+    return Extent(m_begin, m_end-m_begin);
+
+}
+
+size_t ExtentHolder::bytesContained() const {
+    size_t nbytes{0};
+    for (ExtentContainer::const_iterator vit = m_extents.cbegin(); vit != m_extents.cend(); ++vit) {
+        nbytes += vit->len();
+    }
+    return nbytes;
+}
+
+size_t ExtentHolder::bytesMissing() const {
+    size_t bytesUsed = bytesContained();
+    size_t totalRange = asExtent().len(); //might be expensive to call
+    return totalRange - bytesUsed;
+}   
+
+
+void ExtentHolder::sort() {
+        std::sort(m_extents.begin(), m_extents.end());
+}
+
+
+ExtentContainer ExtentHolder::getSortedExtents() const {
+    ExtentContainer v;
+    v.assign(m_extents.begin(), m_extents.end() );
+    std::sort(v.begin(), v.end());
+    return v;
+}
+
+ExtentContainer ExtentHolder::getExtents() const {
+    ExtentContainer v;
+    v.assign(m_extents.begin(), m_extents.end() );
+    return v;
+}
+
+// ------------------------------------------------------ //
+//         Timer ns       //
 
 Timer_ns::Timer_ns(long &output) : m_output_val(output)
 {

--- a/src/XrdCeph/XrdCephBuffers/BufferUtils.cc
+++ b/src/XrdCeph/XrdCephBuffers/BufferUtils.cc
@@ -1,0 +1,15 @@
+
+#include "BufferUtils.hh"
+
+using namespace XrdCephBuffer;
+
+Timer_ns::Timer_ns(long &output) : m_output_val(output)
+{
+    m_start = std::chrono::steady_clock::now();
+}
+
+Timer_ns::~Timer_ns()
+{
+    auto end = std::chrono::steady_clock::now();
+    m_output_val = std::chrono::duration_cast<std::chrono::nanoseconds>(end - m_start).count();
+}

--- a/src/XrdCeph/XrdCephBuffers/BufferUtils.hh
+++ b/src/XrdCeph/XrdCephBuffers/BufferUtils.hh
@@ -3,31 +3,105 @@
 
 // holder of various small utility classes for debugging, profiling, logging, and general stuff
 
+#include <list>
+#include <vector>
 #include <atomic>
 #include <chrono>
+#include <sys/types.h>
 
 
-namespace XrdCephBuffer {
+namespace XrdCephBuffer
+{
 
-class Timer_ns {
+    class Timer_ns
+    {
+        // RAII based timer information in ns
+        // improve to template the output type and the time ratio
     public:
-        explicit Timer_ns(long & output);
+        explicit Timer_ns(long &output_ns);
         ~Timer_ns();
 
     private:
         std::chrono::steady_clock::time_point m_start;
         long &m_output_val;
 
-    // auto start = std::chrono::steady_clock::now();
-    // std::copy( itstart+offset, itstart+(offset+readlength), (char*)buf);
-    // auto end = std::chrono::steady_clock::now();
-    // auto int_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end-start);
+    }; //Timer_ns
 
-};
+    class Extent
+    {
+    public:
+        Extent(off_t offset, size_t len) : m_offset(offset), m_len(len) {}
+        inline off_t offset() const { return m_offset; }
+        inline size_t len() const { return m_len; }
+        inline off_t begin() const { return m_offset; }
+        inline off_t end() const { return m_offset + m_len; } // std::vector style end
+        inline bool empty() const {return m_len == 0;}
+
+        bool isContiguous(const Extent& rhs) const; // does the rhs connect directly to the end of the first
+
+        inline off_t last_pos() const { return m_offset + m_len - 1; } // last real position
+
+        bool in_extent(off_t pos) const;
+        bool allInExtent(off_t pos, size_t len) const;  // is all the range in this extent
+        bool someInExtent(off_t pos, size_t len) const; // is some the range in this extent
+
+        Extent containedExtent(off_t pos, size_t len) const; // return the subset of range that is in this extent
+        Extent containedExtent(const Extent &in) const;        //does the extent
+
+        bool operator<(const Extent &rhs) const;
+        bool operator==(const Extent &rhs) const;
+        
+
+    private:
+        off_t m_offset;
+        size_t m_len;
+    };
 
 
+    typedef std::vector<Extent> ExtentContainer;
+    class ExtentHolder {
+        // holder of a list of extent objects
+        public:
+        ExtentHolder();
+        explicit ExtentHolder(size_t elements); // reserve memory only
+        explicit ExtentHolder(const ExtentContainer& extents);
+        ~ExtentHolder();
+
+        off_t begin() const {return m_begin;}
+        off_t end() const {return m_end;}
+        size_t len() const {return m_end - m_begin;}
+
+        bool empty() const {return m_extents.empty();}
+        size_t size() const {return m_extents.size();}
+
+        Extent asExtent() const; // return an extent covering the whole range
 
 
+        size_t bytesContained() const; // number of bytes across the extent not considering overlaps! 
+        size_t bytesMissing() const; // number of bytes missing across the extent, not considering overlaps!
+
+        void push_back(const Extent & in);
+        void sort();
+
+        const ExtentContainer & extents() const {return m_extents;}
+        //ExtentContainer & extents() {return m_extents;}
+
+        ExtentContainer getSortedExtents() const;
+        ExtentContainer getExtents() const;
+
+
+        protected:
+        ExtentContainer m_extents;
+
+        off_t m_begin{0}; //lowest offset value
+        off_t m_end{0}; // one past end of last byte used. 
+
+    };
+
+    class ExtentMap{
+        // map one range of extents to another range of extents 
+
+    };
 
 
 }

--- a/src/XrdCeph/XrdCephBuffers/BufferUtils.hh
+++ b/src/XrdCeph/XrdCephBuffers/BufferUtils.hh
@@ -1,0 +1,35 @@
+#ifndef __CEPH_BUFFER_UTILS_HH__
+#define __CEPH_BUFFER_UTILS_HH__
+
+// holder of various small utility classes for debugging, profiling, logging, and general stuff
+
+#include <atomic>
+#include <chrono>
+
+
+namespace XrdCephBuffer {
+
+class Timer_ns {
+    public:
+        explicit Timer_ns(long & output);
+        ~Timer_ns();
+
+    private:
+        std::chrono::steady_clock::time_point m_start;
+        long &m_output_val;
+
+    // auto start = std::chrono::steady_clock::now();
+    // std::copy( itstart+offset, itstart+(offset+readlength), (char*)buf);
+    // auto end = std::chrono::steady_clock::now();
+    // auto int_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end-start);
+
+};
+
+
+
+
+
+
+}
+
+#endif

--- a/src/XrdCeph/XrdCephBuffers/BufferUtils.hh
+++ b/src/XrdCeph/XrdCephBuffers/BufferUtils.hh
@@ -8,45 +8,80 @@
 #include <atomic>
 #include <chrono>
 #include <sys/types.h>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <iomanip>
+#include <ctime>
 
+
+// basic logging
+// #TODO; merge this into the xrootd logging, when xrootd is available
+#define CEPHBUFDEBUG 1
+#ifdef CEPHBUFDEBUG
+extern  std::mutex cephbuf_iolock;
+#define BUFLOG(x) {std::unique_lock<std::mutex>(cephbuf_iolock); std::stringstream _bs;  _bs << x; std::clog << _bs.str() << std::endl;}
+#else 
+#define BUFLOG(x)
+#endif
 
 namespace XrdCephBuffer
 {
 
+
     class Timer_ns
     {
-        // RAII based timer information in ns
-        // improve to template the output type and the time ratio
+        /**
+         * @brief RAII based timer information outputing a long value of ns
+         * Almost trivial class to time something and to pass the duration as a long 
+         * to an output variable (specified in the constructor) at destruction.
+         * Create the object to start the timer. The timer stops when its destructor is called.
+         * #TODO improve to template the output type and the time ratio
+         */
     public:
         explicit Timer_ns(long &output_ns);
         ~Timer_ns();
 
     private:
         std::chrono::steady_clock::time_point m_start;
-        long &m_output_val;
+        long &m_output_val; //!< reference to the external variable to store the output.
 
     }; //Timer_ns
 
+
+
     class Extent
     {
+        /**
+         * @brief Ecapsulates an offsets and length, with added functionaliyu
+         * Class that represents an offset possition and a length. 
+         * Simplest usecase is to avoid passing two values around, however this class
+         * provides additional funcationality for manipulation of extends (e.g. merging, splitting)
+         * which may prove useful.
+         */
+
     public:
-        Extent(off_t offset, size_t len) : m_offset(offset), m_len(len) {}
+        Extent(off_t offset, size_t len) : m_offset(offset), m_len(len){}
         inline off_t offset() const { return m_offset; }
         inline size_t len() const { return m_len; }
-        inline off_t begin() const { return m_offset; }
-        inline off_t end() const { return m_offset + m_len; } // std::vector style end
-        inline bool empty() const {return m_len == 0;}
+        inline off_t begin() const { return m_offset; } //!< Same as offset, but a bit more stl container like
+        inline off_t end() const { return m_offset + m_len; } //!< similar to stl vector end.
+        inline bool empty() const {return m_len == 0;} 
 
-        bool isContiguous(const Extent& rhs) const; // does the rhs connect directly to the end of the first
+        /** 
+         *  Does the start of the rhs continue directly from the 
+         * end of this Extent
+        */
+        bool isContiguous(const Extent& rhs) const; 
 
-        inline off_t last_pos() const { return m_offset + m_len - 1; } // last real position
+        inline off_t last_pos() const { return m_offset + m_len - 1; } //!< last real position
 
-        bool in_extent(off_t pos) const;
-        bool allInExtent(off_t pos, size_t len) const;  // is all the range in this extent
-        bool someInExtent(off_t pos, size_t len) const; // is some the range in this extent
+        bool in_extent(off_t pos) const; //!< is this position within the range of this extent
+        bool allInExtent(off_t pos, size_t len) const;  //!< is all the range in this extent
+        bool someInExtent(off_t pos, size_t len) const; //!< is some of the range in this extent
 
-        Extent containedExtent(off_t pos, size_t len) const; // return the subset of range that is in this extent
-        Extent containedExtent(const Extent &in) const;        //does the extent
+        Extent containedExtent(off_t pos, size_t len) const; //!< return the subset of range that is in this extent
+        Extent containedExtent(const Extent &in) const;        //!< 
 
         bool operator<(const Extent &rhs) const;
         bool operator==(const Extent &rhs) const;
@@ -57,22 +92,34 @@ namespace XrdCephBuffer
         size_t m_len;
     };
 
-
+    /**
+     * @brief Container defintion for Extents
+     * Typedef to provide a container of extents as a simple stl vector container
+     */
     typedef std::vector<Extent> ExtentContainer;
+
+    /**
+     * @brief Designed to hold individual extents, but itself provide Extent-like capabilities
+     * Useful in cases of combining extends, or needing to hold a range of extends and extract
+     * information about (or aggregated from) the contained objects.
+     * Could be useful to inherit from Extent if improvements needed.
+     * 
+     * 
+     */
     class ExtentHolder {
         // holder of a list of extent objects
         public:
         ExtentHolder();
-        explicit ExtentHolder(size_t elements); // reserve memory only
+        explicit ExtentHolder(size_t elements); //!< reserve memory only
         explicit ExtentHolder(const ExtentContainer& extents);
         ~ExtentHolder();
 
         off_t begin() const {return m_begin;}
         off_t end() const {return m_end;}
-        size_t len() const {return m_end - m_begin;}
+        size_t len() const {return m_end - m_begin;} //! Total range in bytes of the extents
 
         bool empty() const {return m_extents.empty();}
-        size_t size() const {return m_extents.size();}
+        size_t size() const {return m_extents.size();} //!< number of extent elements 
 
         Extent asExtent() const; // return an extent covering the whole range
 
@@ -81,7 +128,7 @@ namespace XrdCephBuffer
         size_t bytesMissing() const; // number of bytes missing across the extent, not considering overlaps!
 
         void push_back(const Extent & in);
-        void sort();
+        void sort(); //!< inplace sort by offset of contained extents 
 
         const ExtentContainer & extents() const {return m_extents;}
         //ExtentContainer & extents() {return m_extents;}
@@ -90,16 +137,12 @@ namespace XrdCephBuffer
         ExtentContainer getExtents() const;
 
 
+
         protected:
         ExtentContainer m_extents;
 
         off_t m_begin{0}; //lowest offset value
         off_t m_end{0}; // one past end of last byte used. 
-
-    };
-
-    class ExtentMap{
-        // map one range of extents to another range of extents 
 
     };
 

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc
@@ -61,11 +61,20 @@ CephIOAdapterAIORaw::CephIOAdapterAIORaw(IXrdCephBufferData *bufferdata, int fd)
 CephIOAdapterAIORaw::~CephIOAdapterAIORaw()
 {
   // nothing to specifically delete; just print out some stats if in debug
+  float read_speed{0}, write_speed{0};
+  if (m_stats_read_req.load() > 0) {
+    read_speed = m_stats_read_bytes.load() / m_stats_read_timer.load() * 1e-3;
+  }
+  if (m_stats_write_req.load() > 0) {
+    write_speed = m_stats_write_bytes.load() / m_stats_write_timer.load() * 1e-3;
+  }
   BUFLOG("CephIOAdapterAIORaw::Summary fd:" << m_fd
-                                            << " " << m_stats_write_req << " " << m_stats_write_bytes << " "
-                                            << m_stats_write_timer * 1e-3 << " " << m_stats_write_longest * 1e-3
-                                            << " " << m_stats_read_req << " " << m_stats_read_bytes << " "
-                                            << m_stats_read_timer * 1e-3 << "  " << m_stats_read_longest * 1e-3);
+                                            << " nwrite:" << m_stats_write_req << " byteswritten:" << m_stats_write_bytes << " write_s:"
+                                            << m_stats_write_timer * 1e-3 << " writemax_s" << m_stats_write_longest * 1e-3 
+                                            << " write_MBs:" << write_speed 
+                                            << " nread:" << m_stats_read_req << " bytesread:" << m_stats_read_bytes << " read_s:"
+                                            << m_stats_read_timer * 1e-3 << "  readmax_s:" << m_stats_read_longest * 1e-3 
+                                            << " read_MBs:" << read_speed );
 }
 
 ssize_t CephIOAdapterAIORaw::write(off64_t offset, size_t count)

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc
@@ -81,7 +81,7 @@ ssize_t CephIOAdapterAIORaw::write(off64_t offset, size_t count)
 {
   void *buf = m_bufferdata->raw();
   if (!buf)
-    return -EINVAL;
+    return -EINVAL; 
 
   //BUFLOG("Make aio");
   std::unique_ptr<XrdSfsAio> aiop = std::unique_ptr<XrdSfsAio>(new CephBufSfsAio());
@@ -115,8 +115,8 @@ ssize_t CephIOAdapterAIORaw::write(off64_t offset, size_t count)
   // cleanup
   rc = ceph_aiop->Result;
 
-  BUFLOG("CephIOAdapterAIORaw::write fd:" << m_fd << " off:"
-                                          << offset << " len:" << count << " rc:" << rc << " ms:" << dt_ns / 1000000);
+  // BUFLOG("CephIOAdapterAIORaw::write fd:" << m_fd << " off:"
+  //                                         << offset << " len:" << count << " rc:" << rc << " ms:" << dt_ns / 1000000);
 
   m_stats_write_longest = std::max(m_stats_write_longest, dt_ns / 1000000);
   m_stats_write_timer.fetch_add(dt_ns / 1000000);
@@ -178,8 +178,8 @@ ssize_t CephIOAdapterAIORaw::read(off64_t offset, size_t count)
   m_stats_read_bytes.fetch_add(rc);
   ++m_stats_read_req;
 
-  BUFLOG("CephIOAdapterAIORaw::read fd:" << m_fd << " " << offset
-                                         << " " << count << " " << rc << " " << dt_ns * 1e-6);
+  // BUFLOG("CephIOAdapterAIORaw::read fd:" << m_fd << " " << offset
+  //                                        << " " << count << " " << rc << " " << dt_ns * 1e-6);
 
   if (rc >= 0)
   {

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.cc
@@ -1,0 +1,183 @@
+#include "CephIOAdapterAIORaw.hh"
+#include "../XrdCephPosix.hh"
+#include "XrdOuc/XrdOucEnv.hh"
+
+#include <iostream>
+#include <chrono>
+#include <ratio>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <chrono>
+
+using namespace XrdCephBuffer;
+
+using myclock = std::chrono::steady_clock;
+//using myseconds = std::chrono::duration<float,
+
+namespace {
+  static void aioReadCallback(XrdSfsAio *aiop, size_t rc) {
+    // as in XrdCephOssFile
+    aiop->Result = rc;
+    // std::this_thread::sleep_for(std::chrono::seconds(10));
+    BUFLOG("aioReadCallback " << rc);
+    aiop->doneRead();
+  }
+static void aioWriteCallback(XrdSfsAio *aiop, size_t rc) {
+  aiop->Result = rc;
+  BUFLOG("aioWriteCallback " << rc);
+  aiop->doneWrite();
+}
+
+} // anonymous namespace 
+
+CephBufSfsAio::CephBufSfsAio():
+  m_lock(m_mutex) {
+
+}
+
+void CephBufSfsAio::doneRead() {
+  BUFLOG("DoneRead");
+  m_dataOpDone = true;
+  m_lock.unlock();
+  m_condVar.notify_all();
+}
+
+void CephBufSfsAio::doneWrite() {
+  BUFLOG("DoneWrite");
+  m_dataOpDone = true;
+  m_lock.unlock();
+  m_condVar.notify_all();
+}
+
+
+
+
+
+
+CephIOAdapterAIORaw::CephIOAdapterAIORaw(IXrdCephBufferData * bufferdata, int fd) : 
+  m_bufferdata(bufferdata),m_fd(fd) {
+}
+
+CephIOAdapterAIORaw::~CephIOAdapterAIORaw() {
+  // nothing to specifically delete; just print out some stats if in debug
+    BUFLOG ("CephIOAdapterAIORaw::Summary fd:" << m_fd 
+              << " " << m_stats_write_req << " " << m_stats_write_bytes << " "
+              << m_stats_write_timer*1e-3 << " " << m_stats_write_longest*1e-3
+              << " " << m_stats_read_req << " " << m_stats_read_bytes << " "
+               << m_stats_read_timer*1e-3  << "  " << m_stats_read_longest*1e-3);
+            
+}
+
+ssize_t CephIOAdapterAIORaw::write(off64_t offset, size_t count)
+{
+  void *buf = m_bufferdata->raw();
+  if (!buf)
+    return -EINVAL;
+
+  BUFLOG("Make aio");
+  std::unique_ptr<XrdSfsAio> aiop = std::unique_ptr<XrdSfsAio>(new CephBufSfsAio());
+  aiocb &sfsAio = aiop->sfsAio;
+  // set the necessary parameters for the read, e.g. buffer pointer, offset and length
+  sfsAio.aio_buf = buf;
+  sfsAio.aio_nbytes = count;
+  sfsAio.aio_offset = offset;
+  // need the concrete object for the blocking / wait
+  CephBufSfsAio *ceph_aiop = dynamic_cast<CephBufSfsAio *>(aiop.get());
+
+  long dt_ns{0};
+  ssize_t rc{0};
+  {
+    XrdCephBuffer::Timer_ns timer(dt_ns);
+    BUFLOG("Submit aio write: ");
+    rc = ceph_aio_write(m_fd, aiop.get(), aioWriteCallback);
+    BUFLOG("Write aio submit done: " << rc);
+
+    if (rc < 0)
+      return rc;
+
+    BUFLOG("Wait cond: ");
+    while (!ceph_aiop->isDone())
+    {
+      ceph_aiop->m_condVar.wait(ceph_aiop->m_lock, std::bind(&CephBufSfsAio::isDone, ceph_aiop));
+    }
+    BUFLOG("Done wait cond: ");
+  } // timer brace
+
+  // cleanup
+  rc = ceph_aiop->Result;
+
+  BUFLOG("CephIOAdapterAIORaw::write fd:" << m_fd << " "
+                                          << offset << " " << count << " " << rc << " " << dt_ns / 10000000);
+
+  m_stats_write_longest = std::max(m_stats_write_longest, dt_ns / 10000000);
+  m_stats_write_timer.fetch_add(dt_ns / 10000000);
+  m_stats_write_bytes.fetch_add(rc);
+  ++m_stats_write_req;
+  return rc;
+}
+
+ssize_t CephIOAdapterAIORaw::read(off64_t offset, size_t count)
+{
+  void *buf = m_bufferdata->raw();
+  if (!buf)
+  {
+    return -EINVAL;
+  }
+
+  BUFLOG("Make aio");
+  std::unique_ptr<XrdSfsAio> aiop = std::unique_ptr<XrdSfsAio>(new CephBufSfsAio());
+  aiocb &sfsAio = aiop->sfsAio;
+  // set the necessary parameters for the read, e.g. buffer pointer, offset and length
+  sfsAio.aio_buf = buf;
+  sfsAio.aio_nbytes = count;
+  sfsAio.aio_offset = offset;
+  // need the concrete object for the blocking / wait
+  CephBufSfsAio *ceph_aiop = dynamic_cast<CephBufSfsAio *>(aiop.get());
+
+  long dt_ns{0};
+  ssize_t rc{0};
+  {
+    XrdCephBuffer::Timer_ns timer(dt_ns);
+    // no check is made whether the buffer has sufficient capacity
+    //      rc = ceph_posix_pread(m_fd,buf,count,offset);
+    BUFLOG("Submit aio read: ");
+    rc = ceph_aio_read(m_fd, aiop.get(), aioReadCallback);
+    BUFLOG("Read aio submit done: " << rc);
+
+    if (rc < 0)
+      return rc;
+
+    // now block until the read is done
+    // take the lock on the aio object
+    BUFLOG("Getting lock: ");
+    //std::unique_lock<std::mutex> lock(ceph_aiop->m_mutex);
+    // now wait for the condition variable to be set
+    BUFLOG("Wait cond: ");
+    // while(!ceph_aiop->isDone()) { ceph_aiop->m_condVar.wait(lock,std::bind(&CephBufSfsAio::isDone,ceph_aiop) ); }
+    while (!ceph_aiop->isDone())
+    {
+      ceph_aiop->m_condVar.wait(ceph_aiop->m_lock, std::bind(&CephBufSfsAio::isDone, ceph_aiop));
+    }
+    BUFLOG("Done wait cond: ");
+  } // timer brace
+
+  // cleanup
+  rc = ceph_aiop->Result;
+
+  m_stats_read_longest = std::max(m_stats_read_longest, dt_ns / 10000000);
+  m_stats_read_timer.fetch_add(dt_ns * 1e-6);
+  m_stats_read_bytes.fetch_add(rc);
+  ++m_stats_read_req;
+
+  BUFLOG("CephIOAdapterAIORaw::read fd:" << m_fd << " " << offset
+                                         << " " << count << " " << rc << " " << dt_ns * 1e-6);
+
+  if (rc >= 0)
+  {
+    m_bufferdata->setLength(rc);
+    m_bufferdata->setStartingOffset(offset);
+    m_bufferdata->setValid(true);
+  }
+  return rc;
+}

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.hh
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterAIORaw.hh
@@ -1,0 +1,102 @@
+#ifndef __CEPH_IO_ADAPTER_AIORAW_HH__
+#define __CEPH_IO_ADAPTER_AIORAW_HH__
+//------------------------------------------------------------------------------
+// Interface of the logic part of the buffering
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. for different complexities of control.
+// Couples loosely to IXrdCepgBufferData and anticipated to be called by XrdCephOssBufferedFile. 
+// Should managage all of the IO and logic to give XrdCephOssBufferedFile only simple commands to call.
+// implementations are likely to use (via callbacks?) CephPosix library code for actual reads and writes. 
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include "IXrdCephBufferData.hh"
+#include "ICephIOAdapter.hh"
+#include "BufferUtils.hh"
+
+#include <chrono>
+#include <memory>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+
+#include "XrdSfs/XrdSfsAio.hh"
+
+
+namespace XrdCephBuffer {
+
+    class CephBufSfsAio : virtual public XrdSfsAio
+    {
+    public:
+    CephBufSfsAio();
+        // Method to handle completed reads
+        //
+        virtual void doneRead() override;
+
+        // Method to hand completed writes
+        //
+        virtual void doneWrite() override;
+
+        // Method to recycle free object
+        //
+        virtual void Recycle() override{};
+        std::mutex m_mutex;
+        std::unique_lock<std::mutex> m_lock;
+        std::condition_variable m_condVar;
+        bool isDone() {return m_dataOpDone;}
+
+    protected:
+        bool m_dataOpDone {false};
+
+    };
+
+/**
+ * @brief Implements a non-async read and write to ceph via aio ceph_posix calls
+ * Using the standard ceph_posix_aio calls do the actual read and write operations.
+ * No ownership is taken on the buffer that's passed via the constructor
+ * Although using aio calls, we block here until the data has been read/written
+ */
+class CephIOAdapterAIORaw: public  virtual ICephIOAdapter {
+    public:
+        CephIOAdapterAIORaw(IXrdCephBufferData * bufferdata, int fd);
+        virtual ~CephIOAdapterAIORaw();
+
+        /**
+         * @brief Take the data in the buffer and write to ceph at given offset
+         * Issues a ceph_posix_pwrite for data in the buffer (from pos 0) into 
+         * ceph at position offset with len count.
+         * Returns -ve on error, else the number of bytes writen.
+         * 
+         * @param offset 
+         * @param count 
+         * @return ssize_t 
+         */
+        virtual ssize_t write(off64_t offset,size_t count) override;
+
+        /**
+         * @brief Issue a ceph_posix_pread to read to the buffer data from file offset and len count.
+         * No range checking is currently provided here. The caller must provide sufficient space for the 
+         * max len read.
+         * Returns -ve errorcode on failure, else the number of bytes returned. 
+         * 
+         * @param offset 
+         * @param count 
+         * @return ssize_t 
+         */
+        virtual ssize_t read(off64_t offset,size_t count) override;
+
+    private:
+        IXrdCephBufferData * m_bufferdata; //!< no ownership of pointer (consider shared ptrs, etc)
+        int m_fd;
+
+        // timer and counter info
+        std::atomic< long> m_stats_read_timer{0}, m_stats_write_timer{0};
+        std::atomic< long> m_stats_read_bytes{0}, m_stats_write_bytes{0};
+        std::atomic< long> m_stats_read_req{0},   m_stats_write_req{0};
+        long m_stats_read_longest{0}, m_stats_write_longest{0};
+
+};
+
+}
+
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -34,7 +34,7 @@ ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
     auto end = std::chrono::steady_clock::now();
     auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
 
-    BUFLOG("CephIOAdapterRaw::write fd:" << m_fd << " " 
+    BUFLOG("CephIOAdapterRaw::write fd:" << m_fd << " " << rc << " "
               <<  offset << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc < 0) return rc;
@@ -66,7 +66,7 @@ ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     m_stats_read_bytes.fetch_add(rc);
     ++m_stats_read_req;
 
-    BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << offset
+    BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
              << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc>=0) {

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -13,17 +13,16 @@ using myclock = std::chrono::steady_clock;
 
 CephIOAdapterRaw::CephIOAdapterRaw(IXrdCephBufferData * bufferdata, int fd) : 
   m_bufferdata(bufferdata),m_fd(fd) {
-
 }
 
 CephIOAdapterRaw::~CephIOAdapterRaw() {
-    std::clog << "CephIOAdapterRaw::Summary fd:" << m_fd 
+  // nothing to specifically delete; just print out some stats if in debug
+    BUFLOG ("CephIOAdapterRaw::Summary fd:" << m_fd 
               << " " << m_stats_write_req << " " << m_stats_write_bytes << " "
               << m_stats_write_timer*1e-3 << " " << m_stats_write_longest*1e-3
               << " " << m_stats_read_req << " " << m_stats_read_bytes << " "
-               << m_stats_read_timer*1e-3  << "  " << m_stats_read_longest*1e-3
-              << std::endl;
-
+               << m_stats_read_timer*1e-3  << "  " << m_stats_read_longest*1e-3);
+            
 }
 
 ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
@@ -33,14 +32,10 @@ ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
     auto start = std::chrono::steady_clock::now();
     ssize_t rc = ceph_posix_pwrite(m_fd,buf,count,offset);
     auto end = std::chrono::steady_clock::now();
-    //std::chrono::duration<double> elapsed_seconds = end-start;
-    //auto elapsed = end-start;
-    //std::chrono::duration<float> elapsed{end-start};
-    // integral duration: requires duration_cast
     auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
 
-    std::clog << "CephIOAdapterRaw::write fd:" << m_fd << " " 
-              <<  offset << " " << count << " " << rc << " " << int_ms.count() << std::endl;
+    BUFLOG("CephIOAdapterRaw::write fd:" << m_fd << " " 
+              <<  offset << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc < 0) return rc;
     m_stats_write_longest = std::max(m_stats_write_longest,int_ms.count()); 
@@ -57,6 +52,7 @@ ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
       return -EINVAL;
     }
 
+    // no check is made whether the buffer has sufficient capacity
     auto start = std::chrono::steady_clock::now();
     ssize_t rc = ceph_posix_pread(m_fd,buf,count,offset);
     auto end = std::chrono::steady_clock::now();
@@ -70,8 +66,8 @@ ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     m_stats_read_bytes.fetch_add(rc);
     ++m_stats_read_req;
 
-    std::clog << "CephIOAdapterRaw::read fd:" << m_fd << " " << offset
-             << " " << count << " " << rc << " " << int_ms.count()  << std::endl;
+    BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << offset
+             << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc>=0) {
       m_bufferdata->setLength(rc);

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -18,7 +18,7 @@ CephIOAdapterRaw::~CephIOAdapterRaw() {
 
 ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
     const void* buf = m_bufferdata->raw();
-    if (!buf) return -1;
+    if (!buf) return -EINVAL;
     ssize_t rc = ceph_posix_pwrite(m_fd,buf,count,offset);
     std::clog << "CephIOAdapterRaw::write " << offset << " " << count << " " << rc << std::endl;
     return rc;
@@ -26,7 +26,7 @@ ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
 ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     void* buf = m_bufferdata->raw();
     if (!buf) {
-      return -1;
+      return -EINVAL;
     }
 
     ssize_t rc = ceph_posix_pread(m_fd,buf,count,offset);

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -3,9 +3,13 @@
 #include "XrdOuc/XrdOucEnv.hh"
 
 #include <iostream>
+#include <chrono>
+#include <ratio>
 
 using namespace XrdCephBuffer;
 
+using myclock = std::chrono::steady_clock;
+//using myseconds = std::chrono::duration<float,
 
 CephIOAdapterRaw::CephIOAdapterRaw(IXrdCephBufferData * bufferdata, int fd) : 
   m_bufferdata(bufferdata),m_fd(fd) {
@@ -13,24 +17,62 @@ CephIOAdapterRaw::CephIOAdapterRaw(IXrdCephBufferData * bufferdata, int fd) :
 }
 
 CephIOAdapterRaw::~CephIOAdapterRaw() {
+    std::clog << "CephIOAdapterRaw::Summary fd:" << m_fd 
+              << " " << m_stats_write_req << " " << m_stats_write_bytes << " "
+              << m_stats_write_timer*1e-3 << " " << m_stats_write_longest*1e-3
+              << " " << m_stats_read_req << " " << m_stats_read_bytes << " "
+               << m_stats_read_timer*1e-3  << "  " << m_stats_read_longest*1e-3
+              << std::endl;
 
 }
 
 ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
     const void* buf = m_bufferdata->raw();
     if (!buf) return -EINVAL;
+
+    auto start = std::chrono::steady_clock::now();
     ssize_t rc = ceph_posix_pwrite(m_fd,buf,count,offset);
-    std::clog << "CephIOAdapterRaw::write " << offset << " " << count << " " << rc << std::endl;
+    auto end = std::chrono::steady_clock::now();
+    //std::chrono::duration<double> elapsed_seconds = end-start;
+    //auto elapsed = end-start;
+    //std::chrono::duration<float> elapsed{end-start};
+    // integral duration: requires duration_cast
+    auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
+
+    std::clog << "CephIOAdapterRaw::write fd:" << m_fd << " " 
+              <<  offset << " " << count << " " << rc << " " << int_ms.count() << std::endl;
+
+    if (rc < 0) return rc;
+    m_stats_write_longest = std::max(m_stats_write_longest,int_ms.count()); 
+    m_stats_write_timer.fetch_add(int_ms.count());
+    m_stats_write_bytes.fetch_add(rc);
+    ++m_stats_write_req;
     return rc;
 }
+
+
 ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     void* buf = m_bufferdata->raw();
     if (!buf) {
       return -EINVAL;
     }
 
+    auto start = std::chrono::steady_clock::now();
     ssize_t rc = ceph_posix_pread(m_fd,buf,count,offset);
-    std::clog << "CephIOAdapterRaw::read " << offset << " " << count << " " << rc << std::endl;
+    auto end = std::chrono::steady_clock::now();
+    //auto elapsed = end-start;
+    auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
+
+    if (rc < 0) return rc;
+
+    m_stats_read_longest = std::max(m_stats_read_longest,int_ms.count()); 
+    m_stats_read_timer.fetch_add(int_ms.count());
+    m_stats_read_bytes.fetch_add(rc);
+    ++m_stats_read_req;
+
+    std::clog << "CephIOAdapterRaw::read fd:" << m_fd << " " << offset
+             << " " << count << " " << rc << " " << int_ms.count()  << std::endl;
+
     if (rc>=0) {
       m_bufferdata->setLength(rc);
       m_bufferdata->setStartingOffset(offset);

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -1,0 +1,41 @@
+#include "CephIOAdapterRaw.hh"
+#include "../XrdCephPosix.hh"
+#include "XrdOuc/XrdOucEnv.hh"
+
+#include <iostream>
+
+using namespace XrdCephBuffer;
+
+
+CephIOAdapterRaw::CephIOAdapterRaw(IXrdCephBufferData * bufferdata, int fd) : 
+  m_bufferdata(bufferdata),m_fd(fd) {
+
+}
+
+CephIOAdapterRaw::~CephIOAdapterRaw() {
+
+}
+
+ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
+    const void* buf = m_bufferdata->raw();
+    if (!buf) return -1;
+    ssize_t rc = ceph_posix_pwrite(m_fd,buf,count,offset);
+    std::clog << "CephIOAdapterRaw::write " << offset << " " << count << " " << rc << std::endl;
+    return rc;
+}
+ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
+    void* buf = m_bufferdata->raw();
+    if (!buf) {
+      return -1;
+    }
+
+    ssize_t rc = ceph_posix_pread(m_fd,buf,count,offset);
+    std::clog << "CephIOAdapterRaw::read " << offset << " " << count << " " << rc << std::endl;
+    if (rc>=0) {
+      m_bufferdata->setLength(rc);
+      m_bufferdata->setStartingOffset(offset);
+      m_bufferdata->setValid(true);
+    }
+    return rc;
+}
+

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
@@ -13,6 +13,10 @@
 #include "IXrdCephBufferData.hh"
 #include "ICephIOAdapter.hh"
 
+#include <chrono>
+#include <memory>
+#include <atomic>
+
 namespace XrdCephBuffer {
 
 
@@ -27,6 +31,12 @@ class CephIOAdapterRaw: public  virtual ICephIOAdapter {
     private:
         IXrdCephBufferData * m_bufferdata; // no ownership of pointer (consider shared ptrs, etc)
         int m_fd;
+
+        // timer and counter info
+        std::atomic< long> m_stats_read_timer{0}, m_stats_write_timer{0};
+        std::atomic< long> m_stats_read_bytes{0}, m_stats_write_bytes{0};
+        std::atomic< long> m_stats_read_req{0},   m_stats_write_req{0};
+        long m_stats_read_longest{0}, m_stats_write_longest{0};
 
 };
 

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh
@@ -1,0 +1,35 @@
+#ifndef __CEPH_IO_ADAPTER_RAW_HH__
+#define __CEPH_IO_ADAPTER_RAW_HH__
+//------------------------------------------------------------------------------
+// Interface of the logic part of the buffering
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. for different complexities of control.
+// Couples loosely to IXrdCepgBufferData and anticipated to be called by XrdCephOssBufferedFile. 
+// Should managage all of the IO and logic to give XrdCephOssBufferedFile only simple commands to call.
+// implementations are likely to use (via callbacks?) CephPosix library code for actual reads and writes. 
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include "IXrdCephBufferData.hh"
+#include "ICephIOAdapter.hh"
+
+namespace XrdCephBuffer {
+
+
+class CephIOAdapterRaw: public  virtual ICephIOAdapter {
+    public:
+        CephIOAdapterRaw(IXrdCephBufferData * bufferdata, int fd);
+        virtual ~CephIOAdapterRaw();
+
+        virtual ssize_t write(off64_t offset,size_t count) override;
+        virtual ssize_t read(off64_t offset,size_t count) override;
+
+    private:
+        IXrdCephBufferData * m_bufferdata; // no ownership of pointer (consider shared ptrs, etc)
+        int m_fd;
+
+};
+
+}
+
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/ICephIOAdapter.hh
+++ b/src/XrdCeph/XrdCephBuffers/ICephIOAdapter.hh
@@ -1,0 +1,27 @@
+#ifndef __ICEPH_IO_ADAPTER_HH__
+#define __ICEPH_IO_ADAPTER_HH__
+//------------------------------------------------------------------------------
+// Interface of the logic part of the buffering
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. for different complexities of control.
+// Couples loosely to IXrdCepgBufferData and anticipated to be called by XrdCephOssBufferedFile. 
+// Should managage all of the IO and logic to give XrdCephOssBufferedFile only simple commands to call.
+// implementations are likely to use (via callbacks?) CephPosix library code for actual reads and writes. 
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include "IXrdCephBufferData.hh"
+
+namespace XrdCephBuffer {
+
+class ICephIOAdapter {
+    public: 
+        virtual ~ICephIOAdapter() {}
+        virtual ssize_t write(off64_t offset,size_t count) = 0;
+        virtual ssize_t read(off64_t offset,size_t count)  = 0;
+
+};
+
+}
+
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/ICephIOAdapter.hh
+++ b/src/XrdCeph/XrdCephBuffers/ICephIOAdapter.hh
@@ -14,11 +14,19 @@
 
 namespace XrdCephBuffer {
 
+/**
+ * @brief Manage the actual IO operations that read and write the data into Ceph via librados striper.
+ * Likely to be provided with a buffer in the concreate implementation's constructor.
+ * Attempt to decouple the low level IO operations from the buffer implementation.
+ * However, ight coupling might be strictly necessary, making this class a bit redundant.
+ * Consider to refactor if this proves to be the case ... 
+ * 
+ */
 class ICephIOAdapter {
     public: 
         virtual ~ICephIOAdapter() {}
-        virtual ssize_t write(off64_t offset,size_t count) = 0;
-        virtual ssize_t read(off64_t offset,size_t count)  = 0;
+        virtual ssize_t write(off64_t offset,size_t count) = 0; //!< write from buffer into ceph
+        virtual ssize_t read(off64_t offset,size_t count)  = 0; //!< read from ceph into the buffer
 
 };
 

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh
@@ -17,17 +17,22 @@ class XrdSfsAio;
 
 namespace XrdCephBuffer {
 
-
+/**
+ * @brief Interface to a holder of the main logic decisions of the buffering algortithm, decoupled from the buffer resource itself.
+ * Main work of the buffering is done in the classes that inherit from the interace, of how and when and why to buffer and flush the data
+ * The physical representation of the buffer is not written here to allow for some flexibility of changing the internals of the buffer if needed. 
+ * Anticipate that a non-async and async will be the main distinct use cases.
+ */
 class IXrdCephBufferAlg {
     public:
         virtual ~IXrdCephBufferAlg() {}
 
-        virtual ssize_t read_aio (XrdSfsAio *aoip)  = 0;
-        virtual ssize_t write_aio(XrdSfsAio *aoip) = 0;
+        virtual ssize_t read_aio (XrdSfsAio *aoip)  = 0; //!< possible aio based code 
+        virtual ssize_t write_aio(XrdSfsAio *aoip) = 0; //!< possible aio based code
 
-        virtual ssize_t read (volatile void *buff, off_t offset, size_t blen)  = 0;
-        virtual ssize_t write(const void *buff, off_t offset, size_t blen) = 0;
-        virtual ssize_t flushWriteCache() = 0; 
+        virtual ssize_t read (volatile void *buff, off_t offset, size_t blen)  = 0; //!< read data through the buffer
+        virtual ssize_t write(const void *buff, off_t offset, size_t blen) = 0; //!< write data through the buffer
+        virtual ssize_t flushWriteCache() = 0;  //!< remember to flush the cache on final writes
 
 
     protected:

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh
@@ -1,0 +1,42 @@
+#ifndef __IXRD_CEPH_BUFFER_ALG_HH__
+#define __IXRD_CEPH_BUFFER_ALG_HH__
+//------------------------------------------------------------------------------
+// Interface of the logic part of the buffering
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. for different complexities of control.
+// Couples loosely to IXrdCepgBufferData and anticipated to be called by XrdCephOssBufferedFile. 
+// Should managage all of the IO and logic to give XrdCephOssBufferedFile only simple commands to call.
+// implementations are likely to use (via callbacks?) CephPosix library code for actual reads and writes. 
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include "IXrdCephBufferData.hh"
+#include "ICephIOAdapter.hh"
+
+class XrdSfsAio;
+
+namespace XrdCephBuffer {
+
+
+class IXrdCephBufferAlg {
+    public:
+        virtual ~IXrdCephBufferAlg() {}
+
+        virtual ssize_t read_aio (XrdSfsAio *aoip)  = 0;
+        virtual ssize_t write_aio(XrdSfsAio *aoip) = 0;
+
+        virtual ssize_t read (volatile void *buff, off_t offset, size_t blen)  = 0;
+        virtual ssize_t write(const void *buff, off_t offset, size_t blen) = 0;
+        virtual ssize_t flushWriteCache() = 0; 
+
+
+    protected:
+        
+
+    private:
+
+};
+
+}
+
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh
@@ -1,0 +1,40 @@
+#ifndef __IXRD_CEPH_BUFFER_DATA_HH__
+#define __IXRD_CEPH_BUFFER_DATA_HH__
+//------------------------------------------------------------------------------
+// Interface to the actual buffer data object used to store the data
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. if choice of buffer data object 
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+
+namespace XrdCephBuffer {
+
+class IXrdCephBufferData {
+    public:
+        virtual ~IXrdCephBufferData(){}
+        virtual size_t capacity() const = 0;//! total available space
+        virtual size_t length() const  = 0;//! Currently occupied and valid space, which may be less than capacity
+        virtual void   setLength(size_t len) =0 ;//! Currently occupied and valid space, which may be less than capacity
+        virtual bool isValid() const =0;
+        virtual void setValid(bool isValid) =0;
+
+        virtual  off_t startingOffset() const = 0;
+        virtual  off_t setStartingOffset(off_t offset) = 0;
+
+        virtual ssize_t invalidate() = 0; //! set cache into an invalid state
+
+       virtual ssize_t readBuffer(void* buf, off_t offset, size_t blen) const = 0; //! copy data from the internal buffer to buf
+
+       virtual ssize_t writeBuffer(const void* buf, off_t offset, size_t blen,off_t externalOffset)  = 0; //! write data into the buffer, store the external offset
+
+        virtual const void* raw() const = 0;  // const accessor to the 'raw' or underlying object
+        virtual void* raw() = 0; // accessor to the 'raw' or underlying object
+
+
+    protected:
+};
+
+}
+
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh
@@ -10,6 +10,11 @@
 
 namespace XrdCephBuffer {
 
+/**
+ * @brief Interface to the Buffer's  physical representation.
+ * Allow an interface to encapsulate the requirements of a buffer's memory, without worrying about the details.
+ * Various options exist for the specific buffer implemented, and are left to the sub-classes.
+ */
 class IXrdCephBufferData {
     public:
         virtual ~IXrdCephBufferData(){}

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh
@@ -33,6 +33,7 @@ class IXrdCephBufferData {
 
 
     protected:
+    
 };
 
 }

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh
@@ -1,0 +1,61 @@
+#ifndef __IXRD_CEPH_READV_ADAPTER_HH__
+#define __IXRD_CEPH_READV_ADAPTER_HH__
+//------------------------------------------------------------------------------
+// Interface to the actual buffer data object used to store the data
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. if choice of buffer data object 
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include <vector>
+
+#include "XrdOuc/XrdOucIOVec.hh"
+
+//class XrdOucIOVec;
+
+namespace XrdCephBuffer {
+
+typedef std::vector< std::pair<XrdOucIOVec, std::vector<XrdOucIOVec> > >  ReadVMap;
+
+class IXrdCephReadVAdapter {
+    public:
+        virtual ~IXrdCephReadVAdapter(){}
+
+        ReadVMap buildMap(XrdOucIOVec *readV, int n) const; 
+
+    protected:
+};
+
+}
+
+#endif 
+
+/*
+struct XrdOucIOVec
+{
+       long long offset;    // Offset into the file.
+       int       size;      // Size of I/O to perform.
+       int       info;      // Available for arbitrary use
+       char     *data;      // Location to read into.
+};
+
+*/
+
+/*
+ssize_t XrdOssDF::ReadV(XrdOucIOVec *readV,
+                        int          n)
+{
+   ssize_t nbytes = 0, curCount = 0;
+   for (int i=0; i<n; i++)
+       {curCount = Read((void *)readV[i].data,
+                         (off_t)readV[i].offset,
+                        (size_t)readV[i].size);
+        if (curCount != readV[i].size)
+           {if (curCount < 0) return curCount;
+            return -ESPIPE;
+           }
+        nbytes += curCount;
+       }
+   return nbytes;
+}
+*/

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh
@@ -3,59 +3,43 @@
 //------------------------------------------------------------------------------
 // Interface to the actual buffer data object used to store the data
 // Intention to be able to abstract the underlying implementation and code against the inteface
-// e.g. if choice of buffer data object 
+// e.g. if choice of buffer data object
 //------------------------------------------------------------------------------
 
-#include <sys/types.h> 
+#include <sys/types.h>
 #include <vector>
 
-#include "XrdOuc/XrdOucIOVec.hh"
+#include "BufferUtils.hh"
 
-//class XrdOucIOVec;
+#include <iostream> // #FIXME remove
 
-namespace XrdCephBuffer {
+namespace XrdCephBuffer
+{
 
-typedef std::vector< std::pair<XrdOucIOVec, std::vector<XrdOucIOVec> > >  ReadVMap;
-
-class IXrdCephReadVAdapter {
+    /**
+     * @brief Interface to the logic of dealing with readV requests 
+     */
+    class IXrdCephReadVAdapter
+    {
     public:
-        virtual ~IXrdCephReadVAdapter(){}
+        virtual ~IXrdCephReadVAdapter() {}
 
-        ReadVMap buildMap(XrdOucIOVec *readV, int n) const; 
+        /**
+         * @brief Take in a set of extents representing the readV requests. return a vector of each combined read request.
+         * Caller translates the readV request into a set of Extents (passed to an ExtentHolder).
+         * The logic of the specific concrete implementation combines the set of readV requests into merged requests.
+         * Output is a vector of those requests. Each ExtentHolder element holds the offset and len to be read, and also
+         * the contained extents of the readVs.
+         * The index of the readV element is not held, so the caller must ensure to match up appropriately.
+         * 
+         * @param extentsIn 
+         * @return std::vector<ExtentHolder> 
+         */
+        virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsIn) const  =0;
 
     protected:
-};
+    };
 
 }
 
-#endif 
-
-/*
-struct XrdOucIOVec
-{
-       long long offset;    // Offset into the file.
-       int       size;      // Size of I/O to perform.
-       int       info;      // Available for arbitrary use
-       char     *data;      // Location to read into.
-};
-
-*/
-
-/*
-ssize_t XrdOssDF::ReadV(XrdOucIOVec *readV,
-                        int          n)
-{
-   ssize_t nbytes = 0, curCount = 0;
-   for (int i=0; i<n; i++)
-       {curCount = Read((void *)readV[i].data,
-                         (off_t)readV[i].offset,
-                        (size_t)readV[i].size);
-        if (curCount != readV[i].size)
-           {if (curCount < 0) return curCount;
-            return -ESPIPE;
-           }
-        nbytes += curCount;
-       }
-   return nbytes;
-}
-*/
+#endif

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -80,7 +80,7 @@ ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t 
     // No call to flushCache should happen in a read, but be consistent
     const std::lock_guard<std::recursive_mutex> lock(m_data_mutex); // 
 
-    BUFLOG("XrdCephBufferAlgSimple::read: " << offset << " " << blen);
+    //BUFLOG("XrdCephBufferAlgSimple::read: " << offset << " " << blen);
     if (blen == 0) return 0;
 
     /**
@@ -88,8 +88,8 @@ ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t 
      * Invalidate the cache in anycase
      */
     if (blen >= m_bufferdata->capacity()) {
-        BUFLOG("XrdCephBufferAlgSimple::read: Readthrough cache: fd: " << m_fd 
-                  << " " << offset << " " << blen);
+        //BUFLOG("XrdCephBufferAlgSimple::read: Readthrough cache: fd: " << m_fd 
+        //          << " " << offset << " " << blen);
         // larger than cache, so read through, and invalidate the cache anyway
         m_bufferdata->invalidate();
         // #FIXME JW: const_cast is probably a bit poor.
@@ -126,7 +126,7 @@ ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t 
         if (loadCache) {
             m_bufferdata->invalidate();
             rc = m_cephio->read(offset + offsetDelta, m_bufferdata->capacity()); // fill the cache
-            BUFLOG("LoadCache ReadToCache: " << rc << " " << offset + offsetDelta << " " << m_bufferdata->capacity() );
+            //BUFLOG("LoadCache ReadToCache: " << rc << " " << offset + offsetDelta << " " << m_bufferdata->capacity() );
             if (rc < 0) {
                 BUFLOG("LoadCache Error: " << rc);
                 return rc;// TODO return correct errors
@@ -149,12 +149,12 @@ ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t 
         }
         if (rc == 0) {
             // no bytes returned; much be at end of file
-            BUFLOG("No bytes returned: " << rc << "  " << offset << " + " << offsetDelta << "; " << blen << " : " << bytesRemaining);
+            //BUFLOG("No bytes returned: " << rc << "  " << offset << " + " << offsetDelta << "; " << blen << " : " << bytesRemaining);
             break; // leave the loop even though bytesremaing is probably >=0.
             //i.e. requested a full buffers worth, but only a fraction of the file is here.
         }
 
-        BUFLOG("End of loop: " << rc << "  " << offset << " + " << offsetDelta << "; " << blen << " : " << bytesRemaining);
+        //BUFLOG("End of loop: " << rc << "  " << offset << " + " << offsetDelta << "; " << blen << " : " << bytesRemaining);
         offsetDelta    += rc; 
         bytesRemaining -= rc;
         bytesRead      += rc;
@@ -307,7 +307,7 @@ ssize_t XrdCephBufferAlgSimple::write (const void *buf, off_t offset, size_t ble
         bytesWrittenToStorage += rc;
     } // at capacity;
 
-    BUFLOG( "WriteBuffer " << bytesWritten << " " << bytesWrittenToStorage << "  " << offset << "  " << blen << " " );
+    //BUFLOG( "WriteBuffer " << bytesWritten << " " << bytesWrittenToStorage << "  " << offset << "  " << blen << " " );
     return bytesWritten;
 }
 
@@ -317,7 +317,7 @@ ssize_t XrdCephBufferAlgSimple::flushWriteCache()  {
     // Set a lock for any attempt at a simultaneous operation
     // Use recursive, as write (and read) also calls the lock and don't want to deadlock
     const std::lock_guard<std::recursive_mutex> lock(m_data_mutex); // 
-    BUFLOG("flushWriteCache: " << m_bufferStartingOffset << " " << m_bufferLength);
+    // BUFLOG("flushWriteCache: " << m_bufferStartingOffset << " " << m_bufferLength);
     ssize_t rc(-1);
     if (m_bufferLength == 0) {
             BUFLOG("Empty buffer to flush: ");

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -16,21 +16,21 @@
 using namespace XrdCephBuffer;
 
 
-XrdCephBufferAlgSimple::XrdCephBufferAlgSimple(IXrdCephBufferData * buffer, ICephIOAdapter * cephio, int fd ):
-m_bufferdata(buffer), m_cephio(cephio), m_fd(fd){
+XrdCephBufferAlgSimple::XrdCephBufferAlgSimple(std::unique_ptr<IXrdCephBufferData> buffer, std::unique_ptr<ICephIOAdapter> cephio, int fd ):
+m_bufferdata(std::move(buffer)), m_cephio(std::move(cephio)), m_fd(fd){
 
 }
 
 XrdCephBufferAlgSimple::~XrdCephBufferAlgSimple() {
         std::clog << "XrdCephBufferAlgSimple::Destructor fd:" << m_fd << std::endl;
-    if (m_bufferdata) {
-        delete m_bufferdata;
-        m_bufferdata = nullptr;
-    }
-    if (m_cephio) {
-        delete m_cephio;
-        m_cephio = nullptr;
-    }    
+    // if (m_bufferdata) {
+    //     delete m_bufferdata;
+    //     m_bufferdata = nullptr;
+    // }
+    // if (m_cephio) {
+    //     delete m_cephio;
+    //     m_cephio = nullptr;
+    // }    
     m_fd = -1;
 }
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -1,0 +1,260 @@
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include "XrdCephBufferAlgSimple.hh"
+
+#include "../XrdCephPosix.hh"
+#include <XrdOuc/XrdOucEnv.hh>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <iostream>
+
+#include "XrdSfs/XrdSfsAio.hh"
+
+
+using namespace XrdCephBuffer;
+
+
+XrdCephBufferAlgSimple::XrdCephBufferAlgSimple(IXrdCephBufferData * buffer, ICephIOAdapter * cephio, int fd ):
+m_bufferdata(buffer), m_cephio(cephio), m_fd(fd){
+
+}
+
+XrdCephBufferAlgSimple::~XrdCephBufferAlgSimple() {
+    if (m_bufferdata) {
+        delete m_bufferdata;
+        m_bufferdata = nullptr;
+    }
+    m_fd = -1;
+}
+
+
+ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
+    ssize_t rc(-1);
+    if (!aoip) {
+        return -1; // #TODO
+    }
+
+    volatile void  * buf  = aoip->sfsAio.aio_buf;
+    size_t blen  = aoip->sfsAio.aio_nbytes;
+    off_t offset = aoip->sfsAio.aio_offset;
+
+    // translate the aio read into a simple sync read.
+    // hopefully don't get too many out of sequence reads to effect the caching
+    rc = read(buf, offset, blen);
+
+    aoip->Result = rc;
+    aoip->doneRead();
+
+    return rc;
+}
+
+ssize_t XrdCephBufferAlgSimple::write_aio(XrdSfsAio *aoip) {
+    ssize_t rc(-ENOTSUP);
+        // if (!aoip) {
+        //     return -1; 
+        // }
+
+        // volatile void  * buf  = aoip->sfsAio.aio_buf;
+        // size_t blen  = aoip->sfsAio.aio_nbytes;
+        // off_t offset = aoip->sfsAio.aio_offset;
+    size_t blen  = aoip->sfsAio.aio_nbytes;
+    off_t offset = aoip->sfsAio.aio_offset;
+
+    rc = write(const_cast<const void*>(aoip->sfsAio.aio_buf), offset, blen);
+    aoip->Result = rc;
+    aoip->doneWrite();
+    return rc;
+}
+
+
+ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t blen)  {
+    const std::lock_guard<std::recursive_mutex> lock(m_data_mutex); // 
+
+    std::clog << "XrdCephBufferAlgSimple::read: " << offset << " " << blen << std::endl;
+    if (blen == 0) return 0;
+
+    if (blen >= m_bufferdata->capacity()) {
+        std::clog << "XrdCephBufferAlgSimple::read: Readthrough cache: fd: " << m_fd 
+                  << " " << offset << " " << blen << std::endl;
+        // larger than cache, so read through, and invalidate the cache anyway
+        m_bufferdata->invalidate();
+        // #FIXME JW: const_cast is probably a bit dangerous here!
+        return ceph_posix_pread(m_fd, const_cast<void*>(buf), blen, offset);
+    }
+
+    ssize_t rc(-1);
+    size_t bytesRemaining = blen;
+    off_t offsetDelta = 0;
+    size_t bytesRead = 0;
+    while (bytesRemaining > 0) { // in principle, only should ever have the first loop
+        bool loadCache = false;
+        if (m_bufferLength == 0) {
+            // no data in buffer
+            loadCache = true;
+        } else if (offset < m_bufferStartingOffset) {
+            // offset before any cache data 
+            loadCache = true;
+        } else if (offset >=  (off_t) (m_bufferStartingOffset + m_bufferLength) ) {
+            // offset is beyond the stored data
+            loadCache = true;
+        }
+
+        // do we need to read data into the cache?
+        if (loadCache) {
+            m_bufferdata->invalidate();
+            rc = m_cephio->read(offset + offsetDelta, m_bufferdata->capacity()); // fill the cache
+            std::clog << "LoadCache ReadToCache: " << rc << " " << offset + offsetDelta << " " << m_bufferdata->capacity() << std::endl;
+            if (rc < 0) {
+                std::clog << "LoadCache Error: " << rc << std::endl;
+                return rc;// TODO return correct errors
+            }
+            m_bufferStartingOffset = offset + offsetDelta;
+            m_bufferLength = rc;
+            if (rc == 0) {
+                // perhaps at end of file and nothing to read?
+                break;
+            }
+        }
+
+        //now read as much data as possible
+        off_t bufPosition = offset - m_bufferStartingOffset + offsetDelta; 
+        rc =  m_bufferdata->readBuffer( (void*) &(((char*)buf)[offsetDelta]) , bufPosition  + offsetDelta , bytesRemaining);
+        if (rc < 0 ) {
+            std::clog << "Reading from Cache Failed: " << rc << "  " << offsetDelta << "  " << bytesRemaining << std::endl;
+            return -1; // TODO return correct errors
+        }
+        if (rc == 0) {
+            // no bytes returned; much be at end of file
+            std::clog << "No bytes returned: " << rc << "  " << offset << " + " << offsetDelta << "; " << blen << " : " << bytesRemaining << std::endl;
+            break; // leave the loop even though bytesremaing is probably >=0.
+            //i.e. requested a full buffers worth, but only a fraction of the file is here.
+        }
+
+        std::clog << "End of loop: " << rc << "  " << offset << " + " << offsetDelta << "; " << blen << " : " << bytesRemaining << std::endl;
+        offsetDelta    += rc; 
+        bytesRemaining -= rc;
+        bytesRead      += rc;
+
+    } // while bytesremaing
+
+    return bytesRead;
+}
+
+ssize_t XrdCephBufferAlgSimple::write (const void *buf, off_t offset, size_t blen) {
+    const std::lock_guard<std::recursive_mutex> lock(m_data_mutex); // 
+
+    // take the data in buf and put it into the cache; when the cache is full, write to underlying storage
+    // remember to flush the cache at the end of operations ... 
+    ssize_t rc(-1);
+    ssize_t bytesWrittenToStorage(0);
+
+    if (blen == 0) {
+        return 0; // nothing to write; are we done?
+    }
+
+    off_t expected_offset = (off_t)(m_bufferStartingOffset + m_bufferLength);
+
+    if ((offset != expected_offset) && (m_bufferLength > 0) ) {
+        // TODO, might be dangerous to flush the cache on non-aligned writes ... 
+        std::clog << "Non expected offset: " << rc << "  " << offset << "  " << expected_offset << std::endl;
+        // rc = flushWriteCache();
+        // if (rc < 0) {
+        //     return rc; // TODO return correct errors
+        // }
+    } // mismatched offset
+
+    // if (blen >= m_bufferdata->capacity()) {
+    //     // TODO, might be dangerous to flush the cache on non-aligned writes ... 
+    //     // flush the cache now, if needed
+    //     rc = flushWriteCache();
+    //     if (rc < 0) {
+    //         return rc; // TODO return correct errors
+    //     }
+    //     bytesWrittenToStorage += rc;
+
+    //     // Size is larger than the buffer; send the write straight through
+    //     std::clog << "XrdCephBufferAlgSimple::write: Readthrough cache: fd: " << m_fd 
+    //               << " " << offset << " " << blen << std::endl;
+    //     // larger than cache, so read through, and invalidate the cache anyway
+    //     m_bufferdata->invalidate();
+    //     m_bufferLength=0;
+    //     m_bufferStartingOffset=0;
+    //     rc =  ceph_posix_pwrite(m_fd, buf, blen, offset);
+    //     if (rc < 0) {
+    //         return rc; // TODO return correct errors
+    //     }
+    //     bytesWrittenToStorage += rc;
+    //     return rc;
+    // }
+
+    // if needed, we flushed the cache, but maybe the cache is already partly full    
+    size_t bytesRemaining = blen;
+    off_t  offsetDelta = 0;
+    size_t bytesWritten = 0;
+    off_t  bufferOffset = m_bufferLength; // position to append data in the buffer
+
+    while (bytesRemaining > 0) { // expect that only one loop is perfomed, else likely to have written directly
+        if (m_bufferLength == 0) {
+            // empty cache, so set the external offset now
+            m_bufferStartingOffset = offset + offsetDelta;
+        }
+        //add data to the cache
+        rc = m_bufferdata->writeBuffer(buf, bufferOffset, bytesRemaining, 0);
+        if (rc < 0) {
+            std::clog << "WriteBuffer step failed: " << rc << "  " << bufferOffset << "  " << blen << "  " << offset << std::endl;
+            return rc; // TODO return correct errors
+        }
+
+        m_bufferLength += rc;
+        bufferOffset   += rc;
+        bytesWritten   += rc;
+        offsetDelta    += rc;
+        bytesRemaining -= rc;
+
+        if (m_bufferLength == m_bufferdata->capacity()) {
+            rc = flushWriteCache();
+            if (rc < 0) {
+               return rc; // TODO return correct errors
+            }
+            bytesWrittenToStorage += rc;
+        } // at capacity; 
+        
+    } // while byteRemaining
+    std::clog << "WriteBuffer " << bytesWritten << " " << bytesWrittenToStorage << "  " << offset << "  " << blen << " " << std::endl;
+
+
+    return bytesWritten;
+}
+
+
+
+ssize_t XrdCephBufferAlgSimple::flushWriteCache()  {
+    const std::lock_guard<std::recursive_mutex> lock(m_data_mutex); // 
+    std::clog << "flushWriteCache: " << m_bufferStartingOffset << " " << m_bufferLength << std::endl; 
+    ssize_t rc(-1);
+    if (m_bufferLength == 0 ) {
+        return 0; // nothing to be written
+    }
+    // #TODO; the actual write
+    rc = m_cephio->write(m_bufferStartingOffset, m_bufferLength);
+    if (rc < 0) {
+        std::clog << "WriteBuffer write step failed: " << rc << std::endl;
+        return rc;  // TODO return correct errors
+    }
+    m_bufferLength=0;
+    m_bufferStartingOffset=0;
+    m_bufferdata->invalidate();
+    return rc;
+}
+
+
+
+ssize_t XrdCephBufferAlgSimple::rawRead (void *buf,       off_t offset, size_t blen) {
+    return -1;
+}
+
+ssize_t XrdCephBufferAlgSimple::rawWrite(void *buf,       off_t offset, size_t blen) {
+    return -1;
+}

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -31,9 +31,9 @@ XrdCephBufferAlgSimple::~XrdCephBufferAlgSimple() {
 
 
 ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
-    ssize_t rc(-1);
+    ssize_t rc(-ENOSYS);
     if (!aoip) {
-        return -1; // #TODO
+        return -EINVAL; 
     }
 
     volatile void  * buf  = aoip->sfsAio.aio_buf;
@@ -51,10 +51,10 @@ ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
 }
 
 ssize_t XrdCephBufferAlgSimple::write_aio(XrdSfsAio *aoip) {
-    ssize_t rc(-ENOTSUP);
-        // if (!aoip) {
-        //     return -1; 
-        // }
+    ssize_t rc(-ENOSYS);
+        if (!aoip) {
+             return -EINVAL; 
+         }
 
         // volatile void  * buf  = aoip->sfsAio.aio_buf;
         // size_t blen  = aoip->sfsAio.aio_nbytes;
@@ -123,7 +123,7 @@ ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t 
         rc =  m_bufferdata->readBuffer( (void*) &(((char*)buf)[offsetDelta]) , bufPosition  + offsetDelta , bytesRemaining);
         if (rc < 0 ) {
             std::clog << "Reading from Cache Failed: " << rc << "  " << offsetDelta << "  " << bytesRemaining << std::endl;
-            return -1; // TODO return correct errors
+            return rc; // TODO return correct errors
         }
         if (rc == 0) {
             // no bytes returned; much be at end of file
@@ -164,6 +164,10 @@ ssize_t XrdCephBufferAlgSimple::write (const void *buf, off_t offset, size_t ble
         //     return rc; // TODO return correct errors
         // }
     } // mismatched offset
+
+    if ( (m_bufferStartingOffset % m_bufferdata->capacity()) != 0 ) {
+        std::clog << " Non aligned offset?" << m_bufferStartingOffset << " " <<  m_bufferdata->capacity() << " " <<  m_bufferStartingOffset % m_bufferdata->capacity() << std::endl;
+    }
 
     // if (blen >= m_bufferdata->capacity()) {
     //     // TODO, might be dangerous to flush the cache on non-aligned writes ... 
@@ -252,9 +256,9 @@ ssize_t XrdCephBufferAlgSimple::flushWriteCache()  {
 
 
 ssize_t XrdCephBufferAlgSimple::rawRead (void *buf,       off_t offset, size_t blen) {
-    return -1;
+    return -ENOSYS;
 }
 
 ssize_t XrdCephBufferAlgSimple::rawWrite(void *buf,       off_t offset, size_t blen) {
-    return -1;
+    return -ENOSYS;
 }

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -29,8 +29,8 @@ XrdCephBufferAlgSimple::~XrdCephBufferAlgSimple() {
 
 ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
     // Currently this is not supported, and callers using this should recieve the appropriate error code
-    return -ENOSYS;
-    /*
+    //return -ENOSYS;
+    
     ssize_t rc(-ENOSYS);
     if (!aoip) {
         return -EINVAL; 
@@ -48,13 +48,13 @@ ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
     aoip->doneRead();
 
     return rc;
-    */
+    
 }
 
 ssize_t XrdCephBufferAlgSimple::write_aio(XrdSfsAio *aoip) {
     // Currently this is not supported, and callers using this should recieve the appropriate error code
-    return -ENOSYS;
-    /*
+   // return -ENOSYS;
+    
     ssize_t rc(-ENOSYS);
         if (!aoip) {
              return -EINVAL; 
@@ -70,7 +70,7 @@ ssize_t XrdCephBufferAlgSimple::write_aio(XrdSfsAio *aoip) {
     aoip->Result = rc;
     aoip->doneWrite();
     return rc;
-    */
+    
 }
 
 
@@ -319,6 +319,11 @@ ssize_t XrdCephBufferAlgSimple::flushWriteCache()  {
     const std::lock_guard<std::recursive_mutex> lock(m_data_mutex); // 
     BUFLOG("flushWriteCache: " << m_bufferStartingOffset << " " << m_bufferLength);
     ssize_t rc(-1);
+    if (m_bufferLength == 0) {
+            BUFLOG("Empty buffer to flush: ");
+            rc = 0; // not an issue
+    }
+
     if (m_bufferLength > 0) {
         rc = m_cephio->write(m_bufferStartingOffset, m_bufferLength);
         if (rc < 0) {

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -22,15 +22,21 @@ m_bufferdata(buffer), m_cephio(cephio), m_fd(fd){
 }
 
 XrdCephBufferAlgSimple::~XrdCephBufferAlgSimple() {
+        std::clog << "XrdCephBufferAlgSimple::Destructor fd:" << m_fd << std::endl;
     if (m_bufferdata) {
         delete m_bufferdata;
         m_bufferdata = nullptr;
     }
+    if (m_cephio) {
+        delete m_cephio;
+        m_cephio = nullptr;
+    }    
     m_fd = -1;
 }
 
 
 ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
+    return -ENOSYS;
     ssize_t rc(-ENOSYS);
     if (!aoip) {
         return -EINVAL; 
@@ -51,6 +57,7 @@ ssize_t XrdCephBufferAlgSimple::read_aio (XrdSfsAio *aoip) {
 }
 
 ssize_t XrdCephBufferAlgSimple::write_aio(XrdSfsAio *aoip) {
+    return -ENOSYS;
     ssize_t rc(-ENOSYS);
         if (!aoip) {
              return -EINVAL; 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
@@ -1,0 +1,50 @@
+#ifndef __XRD_CEPH_BUFFER_ALG_SIMPLE_HH__
+#define __XRD_CEPH_BUFFER_ALG_SIMPLE_HH__
+//------------------------------------------------------------------------------
+// Implementation of the logic section of buffer code
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include <mutex>
+
+#include "IXrdCephBufferAlg.hh"
+#include "ICephIOAdapter.hh"
+
+
+
+namespace XrdCephBuffer {
+
+class XrdCephBufferAlgSimple : public virtual  IXrdCephBufferAlg {
+    public:
+        XrdCephBufferAlgSimple(IXrdCephBufferData * buffer, ICephIOAdapter * cephio, int fd ); 
+        virtual ~XrdCephBufferAlgSimple();
+
+        virtual ssize_t read_aio (XrdSfsAio *aoip) override;
+        virtual ssize_t write_aio(XrdSfsAio *aoip) override;
+
+
+        virtual ssize_t read (volatile void *buff, off_t offset, size_t blen) override;
+        virtual ssize_t write(const void *buff, off_t offset, size_t blen) override;
+        virtual ssize_t flushWriteCache() override; 
+
+        virtual const IXrdCephBufferData *buffer() const {return m_bufferdata;}
+        virtual IXrdCephBufferData *buffer() {return m_bufferdata;}
+
+    protected:
+        virtual ssize_t rawRead (void *buff,       off_t offset, size_t blen) ; // read from the storage, at its offset
+        virtual ssize_t rawWrite(void *buff,       off_t offset, size_t blen) ; // write to the storage, to its offset posiiton
+
+    private:
+        IXrdCephBufferData * m_bufferdata = nullptr; //! this algorithm takes ownership of the buffer, and will delete it on destruction
+        ICephIOAdapter * m_cephio = nullptr; // no ownership is taken here
+        int m_fd = -1;
+
+        off_t m_bufferStartingOffset = 0;
+        size_t m_bufferLength = 0;
+
+        std::recursive_mutex m_data_mutex; // any data access method on the buffer will use this
+};  
+
+}
+
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
@@ -10,10 +10,19 @@
 
 #include "IXrdCephBufferAlg.hh"
 #include "ICephIOAdapter.hh"
-
+#include "BufferUtils.hh"
 
 
 namespace XrdCephBuffer {
+
+/** Non-async buffering code for non-aio read operations.
+ * Create a single buffer of a given size.
+ * For reads, if data in the buffer read and return the available bytes;
+ *   if no useful data in the buffer fill the full buffer and return the requested read.
+ * If the data is partially in the buffer for the range requested, return only that subset; 
+ * client should check and make an additional call for the data not returned.
+ * if 0 bytes are returned, it should be assumed it is at the end of the file.
+ */
 
 class XrdCephBufferAlgSimple : public virtual  IXrdCephBufferAlg {
     public:

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
@@ -37,6 +37,7 @@ class XrdCephBufferAlgSimple : public virtual  IXrdCephBufferAlg {
         virtual ssize_t write(const void *buff, off_t offset, size_t blen) override;
         virtual ssize_t flushWriteCache() override; 
 
+        // #REVIEW
         virtual const IXrdCephBufferData *buffer() const {return m_bufferdata.get();}
         virtual IXrdCephBufferData *buffer() {return m_bufferdata.get();}
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
@@ -6,6 +6,7 @@
 
 #include <sys/types.h> 
 #include <mutex>
+#include <memory>
 
 #include "IXrdCephBufferAlg.hh"
 #include "ICephIOAdapter.hh"
@@ -16,7 +17,7 @@ namespace XrdCephBuffer {
 
 class XrdCephBufferAlgSimple : public virtual  IXrdCephBufferAlg {
     public:
-        XrdCephBufferAlgSimple(IXrdCephBufferData * buffer, ICephIOAdapter * cephio, int fd ); 
+        XrdCephBufferAlgSimple(std::unique_ptr<IXrdCephBufferData> buffer, std::unique_ptr<ICephIOAdapter> cephio, int fd ); 
         virtual ~XrdCephBufferAlgSimple();
 
         virtual ssize_t read_aio (XrdSfsAio *aoip) override;
@@ -27,16 +28,16 @@ class XrdCephBufferAlgSimple : public virtual  IXrdCephBufferAlg {
         virtual ssize_t write(const void *buff, off_t offset, size_t blen) override;
         virtual ssize_t flushWriteCache() override; 
 
-        virtual const IXrdCephBufferData *buffer() const {return m_bufferdata;}
-        virtual IXrdCephBufferData *buffer() {return m_bufferdata;}
+        virtual const IXrdCephBufferData *buffer() const {return m_bufferdata.get();}
+        virtual IXrdCephBufferData *buffer() {return m_bufferdata.get();}
 
     protected:
         virtual ssize_t rawRead (void *buff,       off_t offset, size_t blen) ; // read from the storage, at its offset
         virtual ssize_t rawWrite(void *buff,       off_t offset, size_t blen) ; // write to the storage, to its offset posiiton
 
     private:
-        IXrdCephBufferData * m_bufferdata = nullptr; //! this algorithm takes ownership of the buffer, and will delete it on destruction
-        ICephIOAdapter * m_cephio = nullptr; // no ownership is taken here
+        std::unique_ptr<IXrdCephBufferData> m_bufferdata; //! this algorithm takes ownership of the buffer, and will delete it on destruction
+        std::unique_ptr<ICephIOAdapter>     m_cephio ; // no ownership is taken here
         int m_fd = -1;
 
         off_t m_bufferStartingOffset = 0;

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <iostream>
 
+
 using  namespace XrdCephBuffer;
 
 
@@ -87,7 +88,12 @@ ssize_t XrdCephBufferDataSimple::readBuffer(void* buf, off_t offset, size_t blen
     
     std::vector<char>::const_iterator itstart = m_buffer.cbegin();
 
+    auto start = std::chrono::steady_clock::now();
     std::copy( itstart+offset, itstart+(offset+readlength), (char*)buf);
+    auto end = std::chrono::steady_clock::now();
+    auto int_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end-start);
+    std::clog << "XrdCephBufferDataSimple::readBuffer: " << offset << " " << readlength << " " << int_ns.count() << std::endl;
+
     return readlength;
 }
 
@@ -116,7 +122,13 @@ ssize_t XrdCephBufferDataSimple::writeBuffer(const void* buf, off_t offset, size
     std::vector<char>::iterator itstart = m_buffer.begin();
     size_t readBytes = blen;
 
+    auto start = std::chrono::steady_clock::now();
     std::copy((char*)buf, (char*)buf +readBytes ,itstart + offset );
+    auto end = std::chrono::steady_clock::now();
+    auto int_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end-start);
+    std::clog << "XrdCephBufferDataSimple::writeBuffer: " << offset << " " << readBytes << " " << int_ns.count() << std::endl;
+
+
 
     m_externalOffset = externalOffset;
     // Decide to set the length of the maximum value that has be written

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
@@ -113,7 +113,7 @@ ssize_t XrdCephBufferDataSimple::readBuffer(void* buf, off_t offset, size_t blen
         // std::copy(rawbufstart + offset, rawbufstart+offset+readlength, reinterpret_cast<char*>(buf) );
         memcpy(reinterpret_cast<char*>(buf), rawbufstart + offset, readlength);
     } // end Timer
-    //BUFLOG("XrdCephBufferDataSimple::readBuffer: " << offset << " " << readlength << " " << int_ns );
+    // BUFLOG("XrdCephBufferDataSimple::readBuffer: " << offset << " " << readlength << " " << int_ns );
 
     return readlength;
 }
@@ -152,7 +152,7 @@ ssize_t XrdCephBufferDataSimple::writeBuffer(const void* buf, off_t offset, size
 
     } // end Timer
 
-    //BUFLOG("XrdCephBufferDataSimple::writeBuffer: " << offset << " " << readBytes << " " << int_ns);
+    // BUFLOG("XrdCephBufferDataSimple::writeBuffer: " << offset << " " << readBytes << " " << int_ns);
 
 
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
@@ -161,7 +161,7 @@ ssize_t XrdCephBufferDataSimple::writeBuffer(const void* buf, off_t offset, size
     // note; unless invalidate is called, then this value may not be correctly set ... 
     m_bufLength      = std::max(offset+blen, m_bufLength);
     m_valid          = true;
-
+ 
 
     return readBytes;
 } 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
@@ -1,0 +1,129 @@
+//------------------------------------------------------------------------------
+//! is a simple implementation of IXrdCephBufferData using std::vector<char> representation for the buffer
+//------------------------------------------------------------------------------
+
+#include "XrdCephBufferDataSimple.hh"
+//#include "XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh"
+#include <errno.h>
+#include <algorithm>
+#include <iostream>
+
+using  namespace XrdCephBuffer;
+
+
+XrdCephBufferDataSimple::XrdCephBufferDataSimple(size_t bufCapacity):
+ m_buffer(bufCapacity,0), m_externalOffset(0),m_bufLength(0) {
+    m_valid = true;
+}
+
+XrdCephBufferDataSimple::~XrdCephBufferDataSimple() {
+    m_valid = false;
+    m_buffer.clear();
+    m_buffer.reserve(0); // just to be paranoid and realse memory immediately
+}
+
+
+size_t XrdCephBufferDataSimple::capacity() const {
+    return m_buffer.capacity();
+}
+
+size_t XrdCephBufferDataSimple::length() const   {
+    return m_bufLength;
+}
+void   XrdCephBufferDataSimple::setLength(size_t len) {
+    m_bufLength = len;
+}
+bool XrdCephBufferDataSimple::isValid() const {
+    return m_valid;
+}
+void XrdCephBufferDataSimple::setValid(bool isValid) {
+    m_valid = isValid;
+}
+
+
+off_t XrdCephBufferDataSimple::startingOffset() const  {
+    return m_externalOffset;
+}
+off_t XrdCephBufferDataSimple::setStartingOffset(off_t offset) {
+    m_externalOffset = offset;
+    return m_externalOffset;
+}
+
+ssize_t XrdCephBufferDataSimple::invalidate() {
+    m_externalOffset = 0;
+    m_bufLength      = 0;
+    m_valid = false;
+    //m_buffer.clear();  // do we really need to clear the elements ?
+    return 0;
+}
+
+
+
+ssize_t XrdCephBufferDataSimple::readBuffer(void* buf, off_t offset, size_t blen) const {
+    // read from the internal buffer to buf (at pos 0), from offset for blen, or max length possible
+    // returns -ve value on error, else the actual number of bytes read
+
+    if (!m_valid) {
+        return -1;
+    }
+    if (offset < 0) {
+        return -1;
+    }
+    if (offset > (ssize_t) m_bufLength) {
+        return 0;
+    }
+    ssize_t readlength = blen;
+    if (offset + blen > m_bufLength) {
+        readlength = m_bufLength - offset;
+    }
+    //std::cout << readlength << " " << blen << " " << m_bufLength << " " << offset << std::endl;
+    if (readlength <0) {
+        return -1;
+    }
+
+    if (readlength == 0) {
+        return 0;
+    }
+    
+    std::vector<char>::const_iterator itstart = m_buffer.cbegin();
+
+    std::copy( itstart+offset, itstart+(offset+readlength), (char*)buf);
+    return readlength;
+}
+
+
+ssize_t XrdCephBufferDataSimple::writeBuffer(const void* buf, off_t offset, size_t blen, off_t externalOffset) {
+    // write data from buf (from pos 0), with length blen, into the buffer at position offset (local to the internal buffer)
+    
+    // #TODO Add test to see if it's in use
+    //invalidate();
+
+    if (offset < 0) {
+        return -1;
+    }
+
+    ssize_t cap = capacity();
+    if ((ssize_t)blen > cap) {
+        return -1;
+    }
+    if ((ssize_t)offset > cap) {
+        return -1;
+    }
+    if (ssize_t(offset + blen) > cap) {
+        return -1;
+    }
+
+    std::vector<char>::iterator itstart = m_buffer.begin();
+    size_t readBytes = blen;
+
+    std::copy((char*)buf, (char*)buf +readBytes ,itstart + offset );
+
+    m_externalOffset = externalOffset;
+    // Decide to set the length of the maximum value that has be written
+    // note; unless invalidate is called, then this value may not be correctly set ... 
+    m_bufLength      = std::max(offset+blen, m_bufLength);
+    m_valid          = true;
+
+
+    return readBytes;
+} 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
@@ -113,7 +113,7 @@ ssize_t XrdCephBufferDataSimple::readBuffer(void* buf, off_t offset, size_t blen
         // std::copy(rawbufstart + offset, rawbufstart+offset+readlength, reinterpret_cast<char*>(buf) );
         memcpy(reinterpret_cast<char*>(buf), rawbufstart + offset, readlength);
     } // end Timer
-    BUFLOG("XrdCephBufferDataSimple::readBuffer: " << offset << " " << readlength << " " << int_ns );
+    //BUFLOG("XrdCephBufferDataSimple::readBuffer: " << offset << " " << readlength << " " << int_ns );
 
     return readlength;
 }
@@ -152,7 +152,7 @@ ssize_t XrdCephBufferDataSimple::writeBuffer(const void* buf, off_t offset, size
 
     } // end Timer
 
-    BUFLOG("XrdCephBufferDataSimple::writeBuffer: " << offset << " " << readBytes << " " << int_ns);
+    //BUFLOG("XrdCephBufferDataSimple::writeBuffer: " << offset << " " << readBytes << " " << int_ns);
 
 
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.cc
@@ -64,10 +64,10 @@ ssize_t XrdCephBufferDataSimple::readBuffer(void* buf, off_t offset, size_t blen
     // returns -ve value on error, else the actual number of bytes read
 
     if (!m_valid) {
-        return -1;
+        return -EINVAL;
     }
     if (offset < 0) {
-        return -1;
+        return -EINVAL;
     }
     if (offset > (ssize_t) m_bufLength) {
         return 0;
@@ -78,7 +78,7 @@ ssize_t XrdCephBufferDataSimple::readBuffer(void* buf, off_t offset, size_t blen
     }
     //std::cout << readlength << " " << blen << " " << m_bufLength << " " << offset << std::endl;
     if (readlength <0) {
-        return -1;
+        return -EINVAL;
     }
 
     if (readlength == 0) {
@@ -99,18 +99,18 @@ ssize_t XrdCephBufferDataSimple::writeBuffer(const void* buf, off_t offset, size
     //invalidate();
 
     if (offset < 0) {
-        return -1;
+        return -EINVAL;
     }
 
     ssize_t cap = capacity();
     if ((ssize_t)blen > cap) {
-        return -1;
+        return -EINVAL;
     }
     if ((ssize_t)offset > cap) {
-        return -1;
+        return -EINVAL;
     }
     if (ssize_t(offset + blen) > cap) {
-        return -1;
+        return -EINVAL;
     }
 
     std::vector<char>::iterator itstart = m_buffer.begin();

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
@@ -8,6 +8,8 @@
 #include "IXrdCephBufferData.hh"
 
 #include <vector>
+#include <atomic>
+#include <chrono>
 
 namespace XrdCephBuffer {
 
@@ -40,6 +42,13 @@ class XrdCephBufferDataSimple :  public virtual IXrdCephBufferData
         std::vector<char> m_buffer; // actual physical buffer
         off_t m_externalOffset = 0; //! what does the first byte of the buffer map to for external offsets
         size_t m_bufLength = 0;  //! length of valid stored data; might be less than the capacity
+
+        // timer and counter info
+        std::atomic< long> m_stats_read_timer{0}, m_stats_write_timer{0};
+        std::atomic< long> m_stats_read_bytes{0}, m_stats_write_bytes{0};
+        std::atomic< long> m_stats_read_req{0},   m_stats_write_req{0};
+        long m_stats_read_longest{0}, m_stats_write_longest{0};
+
 
 }; // XrdCephBufferDataSimple
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
@@ -49,6 +49,9 @@ class XrdCephBufferDataSimple :  public virtual IXrdCephBufferData
         std::atomic< long> m_stats_read_req{0},   m_stats_write_req{0};
         long m_stats_read_longest{0}, m_stats_write_longest{0};
 
+        // staric vars to store the total useage of memory across this class
+        static std::atomic<long> m_total_memory_used;
+        static std::atomic<long> m_total_memory_nbuffers;
 
 }; // XrdCephBufferDataSimple
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
@@ -6,13 +6,20 @@
 
 #include <sys/types.h> 
 #include "IXrdCephBufferData.hh"
-
+#include "BufferUtils.hh"
 #include <vector>
 #include <atomic>
 #include <chrono>
 
 namespace XrdCephBuffer {
 
+/**
+ * @brief Implementation of a buffer using a simple vector<char>
+ * Simplest implementation of a buffer using vector<char> for underlying memory.
+ * Capacity is reserved on construction and released back at destruction.
+ * Does very little itself, except to provide access methods
+ * 
+ */
 class XrdCephBufferDataSimple :  public virtual IXrdCephBufferData
  {
     public:

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh
@@ -1,0 +1,47 @@
+#ifndef __XRD_CEPH_BUFFER_DATA_SIMPLE_HH__
+#define __XRD_CEPH_BUFFER_DATA_SIMPLE_HH__
+//------------------------------------------------------------------------------
+//! is a simple implementation of IXrdCephBufferData using std::vector<char> representation for the buffer
+//------------------------------------------------------------------------------
+
+#include <sys/types.h> 
+#include "IXrdCephBufferData.hh"
+
+#include <vector>
+
+namespace XrdCephBuffer {
+
+class XrdCephBufferDataSimple :  public virtual IXrdCephBufferData
+ {
+    public:
+        XrdCephBufferDataSimple(size_t bufCapacity);
+        virtual ~XrdCephBufferDataSimple();
+        virtual size_t capacity() const override;//! total available space
+        virtual size_t length() const  override;//! Currently occupied and valid space, which may be less than capacity
+        virtual void   setLength(size_t len) override;//! Currently occupied and valid space, which may be less than capacity
+        virtual bool isValid() const override;
+        virtual void setValid(bool isValid) override;
+
+        virtual  off_t startingOffset() const override;
+        virtual  off_t setStartingOffset(off_t offset) override;
+
+
+        virtual ssize_t readBuffer(void* buf, off_t offset, size_t blen) const override; //! copy data from the internal buffer to buf
+
+        virtual ssize_t invalidate() override; //! set cache into an invalid state; do this before writes to be consistent
+        virtual ssize_t writeBuffer(const void* buf, off_t offset, size_t blen, off_t externalOffset=0) override; //! write data into the buffer, store the external offset if provided
+
+        virtual const void* raw() const override {return capacity() > 0 ? &(m_buffer[0]) : nullptr;}
+        virtual void* raw() override {return capacity() > 0 ? &(m_buffer[0]) : nullptr;}
+
+
+    protected:
+        bool m_valid = false;
+        std::vector<char> m_buffer; // actual physical buffer
+        off_t m_externalOffset = 0; //! what does the first byte of the buffer map to for external offsets
+        size_t m_bufLength = 0;  //! length of valid stored data; might be less than the capacity
+
+}; // XrdCephBufferDataSimple
+
+} // namespace 
+#endif 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.cc
@@ -1,0 +1,48 @@
+
+#include "XrdCephReadVBasic.hh"
+#include "BufferUtils.hh"
+
+using namespace XrdCephBuffer;
+
+std::vector<ExtentHolder> XrdCephReadVBasic::convert(const ExtentHolder &extentsHolderInput) const
+{
+    std::vector<ExtentHolder> outputs;
+
+    const ExtentContainer &extentsIn = extentsHolderInput.extents();
+
+    ExtentContainer::const_iterator it = extentsIn.begin();
+    BUFLOG("XrdCephReadVBasic: In size: " << extentsHolderInput.size() << " " << extentsHolderInput.extents().size());
+    while (it != extentsIn.end())
+    {
+        ExtentHolder tmp;
+        while (it != extentsIn.end())
+        {
+            std::clog << "XrdCephReadVBasic: Inner: " << it->begin() << " " << it->len() << std::endl;
+            if (!tmp.size())
+            {
+                tmp.push_back(*it);
+            }
+            else if (it->end() - tmp.begin() < (ssize_t)m_minSize)
+            {
+                tmp.push_back(*it);
+            }
+            else if (((tmp.bytesContained() + it->len()) / (tmp.len() + it->len())) > 0.6)
+            {
+                tmp.push_back(*it);
+            }
+            else if (it->end() - tmp.begin() >= (ssize_t)m_maxSize)
+            {
+                break; // don't make too big
+            }
+            else
+            {
+                break; // didn't fullful logic to include, so start a new extent in next loop
+            }
+            ++it;
+        }
+        BUFLOG("XrdCephReadVBasic: Done Inner: " << tmp.size());
+        outputs.push_back(tmp);
+    }
+
+    return outputs;
+} // convert

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.cc
@@ -11,38 +11,46 @@ std::vector<ExtentHolder> XrdCephReadVBasic::convert(const ExtentHolder &extents
     const ExtentContainer &extentsIn = extentsHolderInput.extents();
 
     ExtentContainer::const_iterator it = extentsIn.begin();
-    BUFLOG("XrdCephReadVBasic: In size: " << extentsHolderInput.size() << " " << extentsHolderInput.extents().size());
     while (it != extentsIn.end())
     {
         ExtentHolder tmp;
-        while (it != extentsIn.end())
-        {
-            std::clog << "XrdCephReadVBasic: Inner: " << it->begin() << " " << it->len() << std::endl;
-            if (!tmp.size())
-            {
-                tmp.push_back(*it);
-            }
-            else if (it->end() - tmp.begin() < (ssize_t)m_minSize)
-            {
-                tmp.push_back(*it);
-            }
-            else if (((tmp.bytesContained() + it->len()) / (tmp.len() + it->len())) > 0.6)
-            {
-                tmp.push_back(*it);
-            }
-            else if (it->end() - tmp.begin() >= (ssize_t)m_maxSize)
-            {
-                break; // don't make too big
-            }
-            else
-            {
-                break; // didn't fullful logic to include, so start a new extent in next loop
-            }
+        int counter(0);
+        while (it != extentsIn.end()) {
+            tmp.push_back(*it); // just put it into an extent
             ++it;
+            ++counter;
+            if (counter > 10 ) break;
         }
-        BUFLOG("XrdCephReadVBasic: Done Inner: " << tmp.size());
+        // while (it != extentsIn.end())
+        // {
+        //     //std::clog << "XrdCephReadVBasic: Inner: " << it->begin() << " " << it->len() << std::endl;
+        //     if (!tmp.size())
+        //     {
+        //         tmp.push_back(*it);
+        //     }
+        //     else if (it->end() - tmp.begin() < (ssize_t)m_minSize)
+        //     {
+        //         tmp.push_back(*it);
+        //     }
+        //     else if (((tmp.bytesContained() + it->len()) / (tmp.len() + it->len())) > 0.6)
+        //     {
+        //         tmp.push_back(*it);
+        //     }
+        //     else if (it->end() - tmp.begin() >= (ssize_t)m_maxSize)
+        //     {
+        //         break; // don't make too big
+        //     }
+        //     else
+        //     {
+        //         break; // didn't fullful logic to include, so start a new extent in next loop
+        //     }
+        //     ++it;
+        // }
+        //BUFLOG("XrdCephReadVBasic: Done Inner: " << tmp.size());
         outputs.push_back(tmp);
     }
+    BUFLOG("XrdCephReadVBasic: In size: " << extentsHolderInput.size() << " " 
+            << extentsHolderInput.extents().size() << " " << outputs.size() );
 
     return outputs;
 } // convert

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.hh
@@ -1,0 +1,42 @@
+#ifndef __IXRD_CEPH_READV_BASIC_HH__
+#define __IXRD_CEPH_READV_BASIC_HH__
+//------------------------------------------------------------------------------
+// Interface to the actual buffer data object used to store the data
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. if choice of buffer data object
+//------------------------------------------------------------------------------
+
+#include <sys/types.h>
+#include <vector>
+
+#include "BufferUtils.hh"
+#include "IXrdCephReadVAdapter.hh"
+
+namespace XrdCephBuffer
+{
+
+    /**
+     * @brief Combine requests into single reads accoriding to some basic rules. 
+     * Read a minimum amount of data (2MiB default), keep adding chunks until the used fraction is lower than some threshold, or 64MiB is reached.
+     * Calling code unraveles the correct ranges for each
+     */
+
+
+    class XrdCephReadVBasic : virtual public IXrdCephReadVAdapter {
+    // nothing more than readV in, and readV out
+    public:
+        XrdCephReadVBasic() {}
+        virtual ~XrdCephReadVBasic() {}
+
+    virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsHolderInput) const override;
+
+    protected:
+        size_t m_minSize = 2*1024*1024;
+        size_t m_maxSize = 64*1024*1024;
+    };
+
+
+
+}
+
+#endif

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.cc
@@ -1,0 +1,22 @@
+
+#include "XrdCephReadVNoOp.hh"
+#include "BufferUtils.hh"
+
+using namespace XrdCephBuffer;
+
+std::vector<ExtentHolder> XrdCephReadVNoOp::convert(const ExtentHolder &extentsHolderInput) const
+{
+    std::vector<ExtentHolder> outputs;
+
+    const ExtentContainer &extentsIn = extentsHolderInput.extents();
+
+    for (ExtentContainer::const_iterator it = extentsIn.begin(); it != extentsIn.end(); ++it)
+    {
+        ExtentHolder tmp;
+        tmp.push_back(*it);
+        outputs.push_back(tmp);
+    } // for
+    // each element in the output contains one element, the
+
+    return outputs;
+} // convert

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.hh
@@ -1,0 +1,38 @@
+#ifndef __IXRD_CEPH_READV_NOOP_HH__
+#define __IXRD_CEPH_READV_NOOP_HH__
+//------------------------------------------------------------------------------
+// Interface to the actual buffer data object used to store the data
+// Intention to be able to abstract the underlying implementation and code against the inteface
+// e.g. if choice of buffer data object
+//------------------------------------------------------------------------------
+
+#include <sys/types.h>
+#include <vector>
+
+#include "BufferUtils.hh"
+#include "IXrdCephReadVAdapter.hh"
+
+namespace XrdCephBuffer
+{
+
+    /**
+     * @brief Passthrough implementation. Convertes the ReadV requests to extents and makes the request.
+     * Does not change how the readV implementation is done, just implements a version with Extents
+     * More for functionality testing, or to allow easier access to readV statistics. 
+     */
+    class XrdCephReadVNoOp : virtual public IXrdCephReadVAdapter {
+    // nothing more than readV in, and readV out
+    public:
+        XrdCephReadVNoOp() {}
+        virtual ~XrdCephReadVNoOp() {}
+
+    virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsHolderInput) const override;
+
+    protected:
+    };
+
+
+
+}
+
+#endif

--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -42,6 +42,7 @@
 #include "XrdCeph/XrdCephOssDir.hh"
 #include "XrdCeph/XrdCephOssFile.hh"
 #include "XrdCeph/XrdCephOssBufferedFile.hh"
+#include "XrdCeph/XrdCephOssReadVFile.hh"
 
 XrdVERSIONINFO(XrdOssGetStorageSystem, XrdCephOss);
 
@@ -290,10 +291,28 @@ XrdOssDF* XrdCephOss::newFile(const char *tident) {
   //TODO create a config to setup the file type and buffer size, etc.
   //return new XrdCephOssFile(this);
   // base instance
-  XrdCephOssFile  * xrdCephOssDF =  new XrdCephOssFile(this);
+  //XrdCephOssFile  * xrdCephOssDF =  new XrdCephOssFile(this);
+  XrdCephOssFile* xrdCephOssDF =  new XrdCephOssFile(this);
+  //return xrdCephOssDF;
+
+  
   if (!m_configBufferEnable) return xrdCephOssDF;
   XrdCephEroute.Say("Ceph Buffermode enabled : size: ", std::to_string(m_configBufferSize).c_str() );
   // wrap with buffer layer and return
-  return new XrdCephOssBufferedFile(xrdCephOssDF, m_configBufferSize);
+  // XrdOssDF  * xrdCXrdCephOssFileephReadV = new XrdCephOssReadVFile(xrdCephOssDF);
+  //return xrdCephReadV;
+//return new XrdCephOssBufferedFile(xrdCephOssDF, m_configBufferSize);
+//return xrdCephReadV;
+  //  return new XrdCephOssBufferedFile(dynamic_cast<XrdCephOssFile*>(xrdCephOssDF), 
+  //                                     m_configBufferSize);
+
+  std::clog << "LogX: " << xrdCephOssDF << " " << dynamic_cast<XrdOssDF*>(xrdCephOssDF) <<  std::endl;
+
+  XrdOssDF  * bufFile = new XrdCephOssBufferedFile(xrdCephOssDF, m_configBufferSize);
+  std::clog << "Log: " << bufFile <<  " " << dynamic_cast<XrdCephOssFile*>(bufFile)  << " " 
+            << dynamic_cast<XrdOssDF*>(bufFile)<< std::endl;
+
+  return new XrdCephOssReadVFile(bufFile);
+
 }
 

--- a/src/XrdCeph/XrdCephOss.hh
+++ b/src/XrdCeph/XrdCephOss.hh
@@ -72,8 +72,11 @@ public:
   virtual XrdOssDF *newFile(const char *tident);
 
   private:
-    bool m_configBufferEnable=false;
-    size_t m_configBufferSize=16*1024*1024L; 
+    bool m_configBufferEnable=false; //! config option for buffering
+    size_t m_configBufferSize=16*1024*1024L;  //! Buffer size
+    bool m_configReadVEnable=false; //! enable readV decorator
+    std::string m_configReadVAlgName="passthrough"; // readV algorithm type
+    
 };
 
 #endif /* __CEPH_OSS_HH__ */

--- a/src/XrdCeph/XrdCephOss.hh
+++ b/src/XrdCeph/XrdCephOss.hh
@@ -71,6 +71,9 @@ public:
   virtual XrdOssDF *newDir(const char *tident);
   virtual XrdOssDF *newFile(const char *tident);
 
+  private:
+    bool m_configBufferEnable=false;
+    size_t m_configBufferSize=16*1024*1024L; 
 };
 
 #endif /* __CEPH_OSS_HH__ */

--- a/src/XrdCeph/XrdCephOssBufferedFile.cc
+++ b/src/XrdCeph/XrdCephOssBufferedFile.cc
@@ -123,10 +123,10 @@ ssize_t XrdCephOssBufferedFile::Read(void *buff, off_t offset, size_t blen) {
 
 int XrdCephOssBufferedFile::Read(XrdSfsAio *aiop) {
 
-  LOGCEPH("XrdCephOssBufferedFile::AIOREAD: fd: " << m_xrdOssDF->getFileDescriptor() << "  "  << time(nullptr) << " : " 
-          << aiop->sfsAio.aio_offset << " " 
-          << aiop->sfsAio.aio_nbytes << " " << aiop->sfsAio.aio_reqprio << " "
-          << aiop->sfsAio.aio_fildes );
+  // LOGCEPH("XrdCephOssBufferedFile::AIOREAD: fd: " << m_xrdOssDF->getFileDescriptor() << "  "  << time(nullptr) << " : " 
+  //         << aiop->sfsAio.aio_offset << " " 
+  //         << aiop->sfsAio.aio_nbytes << " " << aiop->sfsAio.aio_reqprio << " "
+  //         << aiop->sfsAio.aio_fildes );
   
   return m_bufferAlg->read_aio(aiop);
 
@@ -146,10 +146,10 @@ ssize_t XrdCephOssBufferedFile::Write(const void *buff, off_t offset, size_t ble
 }
 
 int XrdCephOssBufferedFile::Write(XrdSfsAio *aiop) {
-  LOGCEPH("XrdCephOssBufferedFile::AIOWRITE: fd: " << m_xrdOssDF->getFileDescriptor() << "  "   << time(nullptr) << " : " 
-          << aiop->sfsAio.aio_offset << " " 
-          << aiop->sfsAio.aio_nbytes << " " << aiop->sfsAio.aio_reqprio << " "
-          << aiop->sfsAio.aio_fildes << " " );
+  // LOGCEPH("XrdCephOssBufferedFile::AIOWRITE: fd: " << m_xrdOssDF->getFileDescriptor() << "  "   << time(nullptr) << " : " 
+  //         << aiop->sfsAio.aio_offset << " " 
+  //         << aiop->sfsAio.aio_nbytes << " " << aiop->sfsAio.aio_reqprio << " "
+  //         << aiop->sfsAio.aio_fildes << " " );
 
   return m_bufferAlg->write_aio(aiop);
 }

--- a/src/XrdCeph/XrdCephOssBufferedFile.cc
+++ b/src/XrdCeph/XrdCephOssBufferedFile.cc
@@ -73,7 +73,7 @@ int XrdCephOssBufferedFile::Open(const char *path, int flags, mode_t mode, XrdOu
     return rc;
   }
   m_fd = m_xrdOssDF->getFileDescriptor();
-  BUFLOG("XrdCephOssBufferedFile::Open got fd: " << rc);
+  BUFLOG("XrdCephOssBufferedFile::Open got fd: " << m_fd << " " << path);
   m_flags = flags; // e.g. for write/read knowledge
 
   // opened a file, so create the buffer here; note - this might be better delegated to the first read/write ...
@@ -100,6 +100,8 @@ int XrdCephOssBufferedFile::Close(long long *retsz) {
         if (rc2 < 0) {
           LOGCEPH( "XrdCephOssBufferedFile::Close: Close error after flush Error fd: " << m_fd << " rc:" << rc2 );
         }
+        // still attempt to close the file; ignore the return error here
+        m_xrdOssDF->Close(retsz);
         return rc; // return the original flush error
     }
   } // check for write

--- a/src/XrdCeph/XrdCephOssBufferedFile.cc
+++ b/src/XrdCeph/XrdCephOssBufferedFile.cc
@@ -121,8 +121,8 @@ int XrdCephOssBufferedFile::Close(long long *retsz) {
   LOGCEPH("XrdCephOssBufferedFile::Summary: {\"fd\":" << m_fd << ", \"Elapsed_time_ms\":" << t_dur 
           << ", \"path\":\"" << m_path  
           << "\", read_B:"   << m_bytesRead.load() 
-          << ", readV_B"     << m_bytesReadV.load() 
-          << ", readAIO_B"   << m_bytesReadAIO.load() 
+          << ", readV_B:"     << m_bytesReadV.load() 
+          << ", readAIO_B:"   << m_bytesReadAIO.load() 
           << ", writeB:"     << m_bytesWrite.load()
           << ", writeAIO_B:" << m_bytesWriteAIO.load()
           << ", startTime:\"" << std::put_time(std::localtime(&t_s), "%F %T") << "\", endTime:\"" 

--- a/src/XrdCeph/XrdCephOssBufferedFile.cc
+++ b/src/XrdCeph/XrdCephOssBufferedFile.cc
@@ -1,0 +1,164 @@
+//------------------------------------------------------------------------------
+// Copyright (c) 2014-2015 by European Organization for Nuclear Research (CERN)
+// Author: Sebastien Ponce <sebastien.ponce@cern.ch>
+//------------------------------------------------------------------------------
+// This file is part of the XRootD software suite.
+//
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//
+// In applying this licence, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//------------------------------------------------------------------------------
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <sstream>
+#include <iostream>
+#include <fcntl.h>
+
+#include "XrdCeph/XrdCephPosix.hh"
+#include "XrdOuc/XrdOucEnv.hh"
+#include "XrdSys/XrdSysError.hh"
+#include "XrdOuc/XrdOucTrace.hh"
+#include "XrdSfs/XrdSfsAio.hh"
+#include "XrdCeph/XrdCephOssFile.hh"
+
+#include "XrdCeph/XrdCephOssBufferedFile.hh"
+#include "XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh"
+#include "XrdCeph/XrdCephBuffers/XrdCephBufferDataSimple.hh"
+#include "XrdCeph/XrdCephBuffers/CephIOAdapterRaw.hh"
+
+using namespace XrdCephBuffer;
+
+extern XrdSysError XrdCephEroute;
+
+XrdCephOssBufferedFile::XrdCephOssBufferedFile(XrdCephOssFile *cephossDF, size_t buffersize):
+m_xrdOssDF(cephossDF), m_bufsize(buffersize) {
+}
+
+XrdCephOssBufferedFile::~XrdCephOssBufferedFile() {
+  // call the destructor of wrapped and delegated classes:
+  if (m_bufferAlg) {
+    delete m_bufferAlg;
+    m_bufferAlg = nullptr;
+  }
+
+  if (m_xrdOssDF) {
+    delete m_xrdOssDF;
+    m_xrdOssDF = nullptr;
+  }
+
+}
+
+
+int XrdCephOssBufferedFile::Open(const char *path, int flags, mode_t mode, XrdOucEnv &env) {
+  int rc = m_xrdOssDF->Open(path, flags, mode, env);
+  if (rc < 0) {
+    return rc;
+  }
+  m_flags = flags; // e.g. for write/read knowledge
+
+  // opened a file, so create the buffer here; note - this might be better delegated elswhere ...
+  // need the file descriptor, so do it after we know the file is opened 
+  IXrdCephBufferData * cephbuffer = new XrdCephBufferDataSimple(m_bufsize);
+  ICephIOAdapter * cephio =  new CephIOAdapterRaw(cephbuffer,m_xrdOssDF->getFileDescriptor()  );
+  // TODO; check for deletion memory leaks
+  m_bufferAlg = new XrdCephBufferAlgSimple(cephbuffer,cephio,m_xrdOssDF->getFileDescriptor());
+  std::stringstream msg; 
+  msg << "XrdCephOssBufferedFile::Open: Buffer created: " << cephbuffer->capacity();
+  XrdCephEroute.Say(msg.str().c_str());
+
+
+  return rc;
+}
+
+int XrdCephOssBufferedFile::Close(long long *retsz) {
+  if ((m_flags & (O_WRONLY|O_RDWR)) != 0) {
+    ssize_t rc = m_bufferAlg->flushWriteCache();
+    if (rc < 0) {
+        std::stringstream msg; 
+        msg << "XrdCephOssBufferedFile::Close: flush ";
+        XrdCephEroute.Say(msg.str().c_str());
+        return rc;
+    }
+  } // check for write
+  // TODO delete cephio, etc
+  
+  if (m_bufferAlg) {
+    delete m_bufferAlg;
+    m_bufferAlg = nullptr;
+  }
+  
+
+  return m_xrdOssDF->Close(retsz);
+}
+
+ssize_t XrdCephOssBufferedFile::Read(off_t offset, size_t blen) {
+  return m_xrdOssDF->Read(offset,blen);
+}
+
+ssize_t XrdCephOssBufferedFile::Read(void *buff, off_t offset, size_t blen) {
+  std::stringstream msg; 
+  msg << "XrdCephOssBufferedFile::Read: " <<  offset << "  " << blen;
+  XrdCephEroute.Say(msg.str().c_str());
+  //  return m_xrdOssDF->Read(buff,offset,blen);
+  return m_bufferAlg->read(buff, offset, blen);
+}
+
+int XrdCephOssBufferedFile::Read(XrdSfsAio *aiop) {
+
+  std::stringstream msg; msg << "XrdCephOssBufferedFile::AIOREAD: "  << time(nullptr) << " : " 
+          << aiop->sfsAio.aio_offset << " " 
+          << aiop->sfsAio.aio_nbytes << " " << aiop->sfsAio.aio_reqprio << " "
+          << aiop->sfsAio.aio_fildes << " " ;
+  XrdCephEroute.Say(msg.str().c_str());
+  
+  //return m_xrdOssDF->Read(aiop);
+  return m_bufferAlg->read_aio(aiop);
+
+}
+
+ssize_t XrdCephOssBufferedFile::ReadRaw(void *buff, off_t offset, size_t blen) {
+  return m_xrdOssDF->ReadRaw(buff, offset, blen);
+}
+
+int XrdCephOssBufferedFile::Fstat(struct stat *buff) {
+  return m_xrdOssDF->Fstat(buff);
+}
+
+ssize_t XrdCephOssBufferedFile::Write(const void *buff, off_t offset, size_t blen) {
+  //return m_xrdOssDF->Write(buff, offset,blen );
+  std::stringstream msg; msg << "XrdCephOssBufferedFile::Write: " <<  offset << "  " << blen;
+  XrdCephEroute.Say(msg.str().c_str());
+  return m_bufferAlg->write(buff, offset, blen);
+}
+
+int XrdCephOssBufferedFile::Write(XrdSfsAio *aiop) {
+  std::stringstream msg; msg << "XrdCephOssBufferedFile::AIOWRITE: "  << time(nullptr) << " : " 
+          << aiop->sfsAio.aio_offset << " " 
+          << aiop->sfsAio.aio_nbytes << " " << aiop->sfsAio.aio_reqprio << " "
+          << aiop->sfsAio.aio_fildes << " " ;
+  XrdCephEroute.Say(msg.str().c_str());
+  //return m_xrdOssDF->Write(aiop); // pass through (slow) for now
+  return m_bufferAlg->write_aio(aiop);
+}
+
+int XrdCephOssBufferedFile::Fsync() {
+  return m_xrdOssDF->Fsync();
+}
+
+int XrdCephOssBufferedFile::Ftruncate(unsigned long long len) {
+  return m_xrdOssDF->Ftruncate(len);
+}

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -22,39 +22,29 @@
 // or submit itself to any jurisdiction.
 //------------------------------------------------------------------------------
 
-#ifndef __XRD_CEPH_OSS_FILE_HH__
-#define __XRD_CEPH_OSS_FILE_HH__
+#ifndef __XRD_CEPH_OSS_BUFFERED_FILE_HH__
+#define __XRD_CEPH_OSS_BUFFERED_FILE_HH__
 
 #include "XrdOss/XrdOss.hh"
 #include "XrdCeph/XrdCephOss.hh"
 
+#include "XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh"
+#include "XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh"
+#include "XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh"
+
+
 //------------------------------------------------------------------------------
-//! This class implements XrdOssDF interface for usage with a CEPH storage.
-//!
-//! This plugin is able to use any pool of ceph with any userId.
-//! There are several ways to provide the pool and userId to be used for a given
-//! operation. Here is the ordered list of possibilities.
-//! First one defined wins :
-//!   - the path can be prepended with userId and pool. Syntax is :
-//!       [[userId@]pool:]<actual path>
-//!   - the XrdOucEnv parameter, when existing, can have 'cephUserId' and/or
-//!     'cephPool' entries
-//!   - the ofs.osslib directive can provide an argument with format :
-//!       [userID@]pool
-//!   - default are 'admin' and 'default' for userId and pool respectively
-//!
-//! Note that the definition of a default via the ofs.osslib directive may
-//! clash with one used in a ofs.xattrlib directive. In case both directives
-//! have a default and they are different, the behavior is not defined.
-//! In case one of the two only has a default, it will be applied for both plugins.
+//! Decorator class XrdCephOssBufferedFile designed to wrap XrdCephOssFile
+//! Functionality for buffered access to/from data in Ceph to avoid inefficient
+//! small reads / writes from the client side
 //------------------------------------------------------------------------------
 
-class XrdCephOssFile : public XrdOssDF {
+class XrdCephOssBufferedFile : public XrdOssDF {
 
 public:
 
-  XrdCephOssFile(XrdCephOss *cephoss);
-  virtual ~XrdCephOssFile() {};
+  XrdCephOssBufferedFile(XrdCephOssFile *cephossDF, size_t buffersize); 
+  virtual ~XrdCephOssBufferedFile();
   virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
   virtual int Close(long long *retsz=0);
   virtual ssize_t Read(off_t offset, size_t blen);
@@ -67,12 +57,11 @@ public:
   virtual int Fsync(void);
   virtual int Ftruncate(unsigned long long);
 
-  inline int getFileDescriptor() const {return m_fd;}
-private:
-
-  int m_fd;
-  XrdCephOss *m_cephOss;
-
+protected:
+  XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
+  XrdCephBuffer::IXrdCephBufferAlg * m_bufferAlg = nullptr;
+  int m_flags = 0;
+  size_t m_bufsize = 16*1024*1024L;
 };
 
-#endif /* __XRD_CEPH_OSS_FILE_HH__ */
+#endif /* __XRD_CEPH_OSS_BUFFERED_FILE_HH__ */

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -45,7 +45,7 @@
 class XrdCephOssBufferedFile : virtual public XrdCephOssFile { // XrdOssDF
 
 public:
-  XrdCephOssBufferedFile(XrdCephOssFile *cephossDF, size_t buffersize); 
+  XrdCephOssBufferedFile(XrdCephOss *cephoss,XrdCephOssFile *cephossDF, size_t buffersize); 
   //explicit XrdCephOssBufferedFile(size_t buffersize); 
   virtual ~XrdCephOssBufferedFile();
   virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
@@ -62,6 +62,7 @@ public:
   virtual int Ftruncate(unsigned long long);
 
 protected:
+  XrdCephOss *m_cephoss  = nullptr;
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
   std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg>(m_bufferAlg);
 

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -32,6 +32,8 @@
 #include "XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh"
 #include "XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh"
 
+#include <memory>
+
 
 //------------------------------------------------------------------------------
 //! Decorator class XrdCephOssBufferedFile designed to wrap XrdCephOssFile
@@ -59,7 +61,8 @@ public:
 
 protected:
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
-  XrdCephBuffer::IXrdCephBufferAlg * m_bufferAlg = nullptr;
+  std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg>(m_bufferAlg);
+
   int m_flags = 0;
   size_t m_bufsize = 16*1024*1024L; // default 16MiB size
 };

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -27,6 +27,7 @@
 
 #include "XrdOss/XrdOss.hh"
 #include "XrdCeph/XrdCephOss.hh"
+#include "XrdCeph/XrdCephOssFile.hh"
 
 #include "XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh"
 #include "XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh"
@@ -41,17 +42,18 @@
 //! small reads / writes from the client side
 //------------------------------------------------------------------------------
 
-class XrdCephOssBufferedFile : public XrdOssDF {
+class XrdCephOssBufferedFile : virtual public XrdCephOssFile { // XrdOssDF
 
 public:
-
   XrdCephOssBufferedFile(XrdCephOssFile *cephossDF, size_t buffersize); 
+  //explicit XrdCephOssBufferedFile(size_t buffersize); 
   virtual ~XrdCephOssBufferedFile();
   virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
   virtual int Close(long long *retsz=0);
   virtual ssize_t Read(off_t offset, size_t blen);
   virtual ssize_t Read(void *buff, off_t offset, size_t blen);
   virtual int     Read(XrdSfsAio *aoip);
+  virtual ssize_t ReadV(XrdOucIOVec *readV, int rdvcnt);
   virtual ssize_t ReadRaw(void *, off_t, size_t);
   virtual int Fstat(struct stat *buff);
   virtual ssize_t Write(const void *buff, off_t offset, size_t blen);

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -61,7 +61,7 @@ protected:
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
   XrdCephBuffer::IXrdCephBufferAlg * m_bufferAlg = nullptr;
   int m_flags = 0;
-  size_t m_bufsize = 16*1024*1024L;
+  size_t m_bufsize = 16*1024*1024L; // default 16MiB size
 };
 
 #endif /* __XRD_CEPH_OSS_BUFFERED_FILE_HH__ */

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -34,6 +34,8 @@
 #include "XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh"
 
 #include <memory>
+#include <chrono>
+#include <atomic>
 
 
 //------------------------------------------------------------------------------
@@ -68,6 +70,13 @@ protected:
 
   int m_flags = 0;
   size_t m_bufsize = 16*1024*1024L; // default 16MiB size
+  std::string m_path;
+  std::chrono::time_point<std::chrono::system_clock> m_timestart;
+  std::atomic<size_t> m_bytesRead    = {0}; /// number of bytes read or written
+  std::atomic<size_t> m_bytesReadV   = {0}; /// number of bytes read or written
+  std::atomic<size_t> m_bytesReadAIO = {0}; /// number of bytes read or written
+  std::atomic<size_t> m_bytesWrite   = {0}; /// number of bytes read or written
+  std::atomic<size_t> m_bytesWriteAIO= {0}; /// number of bytes read or written
 };
 
 #endif /* __XRD_CEPH_OSS_BUFFERED_FILE_HH__ */

--- a/src/XrdCeph/XrdCephOssFile.hh
+++ b/src/XrdCeph/XrdCephOssFile.hh
@@ -68,7 +68,7 @@ public:
   virtual int Ftruncate(unsigned long long);
 
   inline virtual int getFileDescriptor() const {return m_fd;}
-private:
+protected:
 
   int m_fd;
   XrdCephOss *m_cephOss;

--- a/src/XrdCeph/XrdCephOssFile.hh
+++ b/src/XrdCeph/XrdCephOssFile.hh
@@ -49,11 +49,11 @@
 //! In case one of the two only has a default, it will be applied for both plugins.
 //------------------------------------------------------------------------------
 
-class XrdCephOssFile : public XrdOssDF {
+class XrdCephOssFile : virtual public XrdOssDF {
 
 public:
 
-  XrdCephOssFile(XrdCephOss *cephoss);
+  explicit XrdCephOssFile(XrdCephOss *cephoss);
   virtual ~XrdCephOssFile() {};
   virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
   virtual int Close(long long *retsz=0);
@@ -67,7 +67,7 @@ public:
   virtual int Fsync(void);
   virtual int Ftruncate(unsigned long long);
 
-  inline int getFileDescriptor() const {return m_fd;}
+  inline virtual int getFileDescriptor() const {return m_fd;}
 private:
 
   int m_fd;

--- a/src/XrdCeph/XrdCephOssReadVFile.cc
+++ b/src/XrdCeph/XrdCephOssReadVFile.cc
@@ -94,17 +94,17 @@ ssize_t XrdCephOssReadVFile::ReadV(XrdOucIOVec *readV, int rnum) {
   int fd = m_xrdOssDF->getFileDescriptor();
   LOGCEPH("XrdCephOssReadVFile::ReadV: fd: " << fd  << " " << rnum << "\n" );
 
-  std::stringstream msg_extents; 
-  msg_extents << "EXTENTS=[";
+  //std::stringstream msg_extents; 
+  //msg_extents << "EXTENTS=[";
 
   ExtentHolder extents(rnum);
   for (int i = 0; i < rnum; i++) {
     extents.push_back(Extent(readV[i].offset, readV[i].size));
-    msg_extents << "(" << readV[i].offset << "," << readV[i].size << ")," ;
+    //msg_extents << "(" << readV[i].offset << "," << readV[i].size << ")," ;
   }
-  msg_extents << "]";
+  //msg_extents << "]";
   //XrdCephEroute.Say(msg_extents.str().c_str()); msg_extents.clear();
-  LOGCEPH(msg_extents.str());
+  //LOGCEPH(msg_extents.str());
 
   LOGCEPH("Extents: fd: "<< fd << " "  << extents.size() << " " << extents.len() << " " 
       << extents.begin() << " " << extents.end() << " " << extents.bytesContained() 
@@ -127,12 +127,12 @@ ssize_t XrdCephOssReadVFile::ReadV(XrdOucIOVec *readV, int rnum) {
   buffer.reserve(buffersize);
 
 
-  LOGCEPH("mappedExtents: len: " << mappedExtents.size() );
+  //LOGCEPH("mappedExtents: len: " << mappedExtents.size() );
   for (std::vector<ExtentHolder>::const_iterator ehit = mappedExtents.cbegin(); ehit!= mappedExtents.cend(); ++ehit ) {
     off_t off = ehit->begin();
     size_t len = ehit->len();
 
-    LOGCEPH("outerloop: " << off << " " << len << " " << ehit->end() << " " << " " << ehit->size() );
+    //LOGCEPH("outerloop: " << off << " " << len << " " << ehit->end() << " " << " " << ehit->size() );
 
     // read the full extent into the buffer
     long timed_read_ns{0};
@@ -160,9 +160,9 @@ ssize_t XrdCephOssReadVFile::ReadV(XrdOucIOVec *readV, int rnum) {
     for (ExtentContainer::const_iterator it = innerExtents.cbegin(); it != innerExtents.cend(); ++it) {
       off_t innerBegin = it->begin() - off;
       off_t innerEnd   = it->end()   - off; 
-      LOGCEPH( "innerloop: " << innerBegin << " " << innerEnd << " " << off << " " 
-                << it->begin() << " " << it-> end() << " " 
-                << readV[counter].offset << " " << readV[counter].size);
+      //LOGCEPH( "innerloop: " << innerBegin << " " << innerEnd << " " << off << " " 
+      //          << it->begin() << " " << it-> end() << " " 
+      //          << readV[counter].offset << " " << readV[counter].size);
       std::copy(data+innerBegin, data+innerEnd, readV[counter].data );
       nbytes += it->len();
       ++counter; // next element

--- a/src/XrdCeph/XrdCephOssReadVFile.cc
+++ b/src/XrdCeph/XrdCephOssReadVFile.cc
@@ -1,0 +1,192 @@
+//------------------------------------------------------------------------------
+// Copyright (c) 2014-2015 by European Organization for Nuclear Research (CERN)
+// Author: Sebastien Ponce <sebastien.ponce@cern.ch>
+//------------------------------------------------------------------------------
+// This file is part of the XRootD software suite.
+//
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//
+// In applying this licence, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//------------------------------------------------------------------------------
+
+#include <sys/types.h>
+#include <unistd.h>
+#include <sstream>
+#include <iostream>
+#include <memory>
+#include <algorithm>
+#include <fcntl.h>
+
+#include "XrdCeph/XrdCephPosix.hh"
+#include "XrdOuc/XrdOucEnv.hh"
+#include "XrdSys/XrdSysError.hh"
+#include "XrdOuc/XrdOucTrace.hh"
+#include "XrdSfs/XrdSfsAio.hh"
+#include "XrdCeph/XrdCephOssFile.hh"
+
+#include "XrdCeph/XrdCephOssReadVFile.hh"
+#include "XrdCeph/XrdCephBuffers/BufferUtils.hh"
+
+using namespace XrdCephBuffer;
+
+extern XrdSysError XrdCephEroute;
+
+XrdCephOssReadVFile::XrdCephOssReadVFile(XrdCephOss *cephoss,XrdCephOssFile *cephossDF):
+XrdCephOssFile(cephoss), m_cephoss(cephoss), m_xrdOssDF(cephossDF)
+{
+    if (!m_xrdOssDF) XrdCephEroute.Say("XrdCephOssReadVFile::Null m_xrdOssDF");
+}
+
+XrdCephOssReadVFile::~XrdCephOssReadVFile() {
+    XrdCephEroute.Say("XrdCephOssReadVFile::Destructor");
+
+  if (m_xrdOssDF) {
+    delete m_xrdOssDF;
+    m_xrdOssDF = nullptr;
+  }
+
+}
+
+int XrdCephOssReadVFile::Open(const char *path, int flags, mode_t mode, XrdOucEnv &env) {
+  std::stringstream msg; 
+  msg << "XrdCephOssReadVFile::Opening" ; 
+  XrdCephEroute.Say(msg.str().c_str());
+  msg.flush();
+
+  int rc = m_xrdOssDF->Open(path, flags, mode, env);
+  if (rc < 0) {
+    return rc;
+  }
+  m_fd = m_xrdOssDF->getFileDescriptor();
+  std::stringstream msg2; 
+  msg2 << "XrdCephOssReadVFile::Open: fd: " << m_xrdOssDF->getFileDescriptor(); 
+  XrdCephEroute.Say(msg2.str().c_str());
+
+  return rc;
+}
+
+int XrdCephOssReadVFile::Close(long long *retsz) {
+  return m_xrdOssDF->Close(retsz);
+}
+
+
+ssize_t XrdCephOssReadVFile::ReadV(XrdOucIOVec *readV, int rnum) {
+  int fd = m_xrdOssDF->getFileDescriptor();
+  std::stringstream msg; 
+  msg << "XrdCephOssReadVFile::ReadV: fd: " << fd  << " " << rnum << "\n";
+  XrdCephEroute.Say(msg.str().c_str()); msg.clear();
+
+  ExtentHolder extents(rnum);
+  for (int i = 0; i < rnum; i++) {
+    extents.push_back(Extent(readV[i].offset, readV[i].size));
+  }
+  msg.clear(); 
+  msg << "Extents: fd: "<< fd << " "  << extents.size() << " " << extents.len() << " " 
+      << extents.begin() << " " << extents.end() << " " << extents.bytesContained() 
+      << " " << extents.bytesMissing();
+  XrdCephEroute.Say(msg.str().c_str());
+
+  //std::unique_ptr<XrdCephBuffer::IXrdCephReadVAdapter> readVAdapter(new XrdCephBuffer::XrdCephReadVNoOp());
+  std::unique_ptr<XrdCephBuffer::IXrdCephReadVAdapter> readVAdapter(new XrdCephBuffer::XrdCephReadVBasic());
+
+  std::vector<ExtentHolder> mappedExtents = readVAdapter->convert(extents);
+
+  size_t totalBytesRead(0), totalBytesUseful(0);
+
+  int nbytes = 0, curCount = 0, counter(0);
+
+  std:: clog << "mappedExtents: " << mappedExtents.size() << std::endl;
+  for (std::vector<ExtentHolder>::const_iterator ehit = mappedExtents.cbegin(); ehit!= mappedExtents.cend(); ++ehit ) {
+    off_t off = ehit->begin();
+    size_t len = ehit->len();
+
+    std:: clog << "outerloop: " << off << " " << len << " " << ehit->end() << " " << " " << ehit->size() << std::endl;
+
+    // read the full extent into the buffer
+    // #fixme
+    std::vector<char> buffer;
+    buffer.reserve(len);
+    curCount = m_xrdOssDF->Read(buffer.data(), off, len);
+    std:: clog << "buf Read " << curCount << std::endl;
+    if (curCount != (ssize_t)len) {
+      return (curCount < 0 ? curCount : -ESPIPE);
+    }
+    totalBytesRead += curCount;
+    totalBytesUseful += ehit->bytesContained(); 
+
+    // now read out into the original readV requests
+    const char* data = buffer.data();
+    const ExtentContainer& innerExtents = ehit->extents();
+    for (ExtentContainer::const_iterator it = innerExtents.cbegin(); it != innerExtents.cend(); ++it) {
+      off_t innerBegin = it->begin() - off;
+      off_t innerEnd   = it->end()   - off; 
+      std:: clog << "innerloop: " << innerBegin << " " << innerEnd << " " << off << " " << it->begin() << " " << it-> end() << " " << readV[counter].offset << " " << readV[counter].size <<  std::endl;
+      std::copy(data+innerBegin, data+innerEnd, readV[counter].data);
+      nbytes += it->len();
+      ++counter; // next element
+    } // inner extents
+
+  } // outer extents
+  std::clog << "readV returning " << nbytes << " bytes: " << "Read:  " <<totalBytesRead << " Useful: " << totalBytesUseful  << endl;
+  return nbytes;
+
+    // int nbytes = 0, curCount = 0;
+
+    // for (int i = 0; i < rnum; i++)
+    // {
+    //   curCount = m_xrdOssDF->Read(readV[i].data, readV[i].offset, readV[i].size);
+    //   if (curCount != readV[i].size)
+    //     return (curCount < 0 ? curCount : -ESPIPE);
+    //   nbytes += curCount;
+    // }
+    // return nbytes;
+}
+
+ssize_t XrdCephOssReadVFile::Read(off_t offset, size_t blen) {
+  return m_xrdOssDF->Read(offset,blen);
+}
+
+ssize_t XrdCephOssReadVFile::Read(void *buff, off_t offset, size_t blen) {
+  return m_xrdOssDF->Read(buff,offset,blen);
+}
+
+int XrdCephOssReadVFile::Read(XrdSfsAio *aiop) {
+  return m_xrdOssDF->Read(aiop);
+}
+
+ssize_t XrdCephOssReadVFile::ReadRaw(void *buff, off_t offset, size_t blen) {
+  return m_xrdOssDF->ReadRaw(buff, offset, blen);
+}
+
+int XrdCephOssReadVFile::Fstat(struct stat *buff) {
+  return m_xrdOssDF->Fstat(buff);
+}
+
+ssize_t XrdCephOssReadVFile::Write(const void *buff, off_t offset, size_t blen) {
+  return m_xrdOssDF->Write(buff,offset,blen);
+}
+
+int XrdCephOssReadVFile::Write(XrdSfsAio *aiop) {
+  return m_xrdOssDF->Write(aiop);
+}
+
+int XrdCephOssReadVFile::Fsync() {
+  return m_xrdOssDF->Fsync();
+}
+
+int XrdCephOssReadVFile::Ftruncate(unsigned long long len) {
+  return m_xrdOssDF->Ftruncate(len);
+}

--- a/src/XrdCeph/XrdCephOssReadVFile.hh
+++ b/src/XrdCeph/XrdCephOssReadVFile.hh
@@ -47,7 +47,7 @@ class XrdCephOssReadVFile : virtual public XrdCephOssFile {
 
 public:
 
-  explicit XrdCephOssReadVFile(XrdCephOss *cephoss, XrdCephOssFile *cephossDF); 
+  explicit XrdCephOssReadVFile(XrdCephOss *cephoss, XrdCephOssFile *cephossDF,const std::string& algname); 
   virtual ~XrdCephOssReadVFile();
   virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
   virtual int Close(long long *retsz=0);
@@ -76,6 +76,15 @@ public:
 protected:
   XrdCephOss *m_cephoss  = nullptr;
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
+  std::string m_algname = "passthrough";
+  std::unique_ptr<XrdCephBuffer::IXrdCephReadVAdapter> m_readVAdapter;
+
+  std::atomic<long> m_timer_read_ns {0}; //! timer for the reads against ceph
+  std::atomic<long> m_timer_count {0}; //! number of reads
+  std::atomic<long> m_timer_size {0}; //! number of reads
+  std::atomic<long> m_timer_longest {0}; //! size read in bytes
+
+
 };
 
 #endif /* __XRD_CEPH_OSS_READV_FILE_HH__ */

--- a/src/XrdCeph/XrdCephOssReadVFile.hh
+++ b/src/XrdCeph/XrdCephOssReadVFile.hh
@@ -1,0 +1,81 @@
+//------------------------------------------------------------------------------
+// Copyright (c) 2014-2015 by European Organization for Nuclear Research (CERN)
+// Author: Sebastien Ponce <sebastien.ponce@cern.ch>
+//------------------------------------------------------------------------------
+// This file is part of the XRootD software suite.
+//
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//
+// In applying this licence, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//------------------------------------------------------------------------------
+
+#ifndef __XRD_CEPH_OSS_READV_FILE_HH__
+#define __XRD_CEPH_OSS_READV_FILE_HH__
+
+#include "XrdOss/XrdOss.hh"
+#include "XrdCeph/XrdCephOss.hh"
+#include "XrdCeph/XrdCephOssFile.hh"
+
+#include "XrdCeph/XrdCephBuffers/IXrdCephBufferData.hh"
+#include "XrdCeph/XrdCephBuffers/IXrdCephBufferAlg.hh"
+#include "XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh"
+
+#include <memory>
+
+
+//------------------------------------------------------------------------------
+//! Decorator class XrdCephOssReadVFile designed to wrap XrdCephOssFile
+//! Functionality for ReadV access to/from data in Ceph to avoid inefficient
+//! small reads / writes from the client side.
+//! Initially for monitoring purposes
+//------------------------------------------------------------------------------
+
+class XrdCephOssReadVFile : virtual public XrdCephOssFile {
+
+public:
+
+  explicit XrdCephOssReadVFile(XrdCephOss *cephoss, XrdCephOssFile *cephossDF); 
+  virtual ~XrdCephOssReadVFile();
+  virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
+  virtual int Close(long long *retsz=0);
+
+//-----------------------------------------------------------------------------
+//! Read file bytes as directed by the read vector.
+//!
+//! @param  readV     pointer to the array of read requests.
+//! @param  rdvcnt    the number of elements in readV.
+//!
+//! @return >=0       The numbe of bytes read.
+//! @return < 0       -errno or -osserr upon failure (see XrdOssError.hh).
+//-----------------------------------------------------------------------------
+  virtual ssize_t ReadV(XrdOucIOVec *readV, int rdvcnt);
+
+  virtual ssize_t Read(off_t offset, size_t blen);
+  virtual ssize_t Read(void *buff, off_t offset, size_t blen);
+  virtual int     Read(XrdSfsAio *aoip);
+  virtual ssize_t ReadRaw(void *, off_t, size_t);
+  virtual int Fstat(struct stat *buff);
+  virtual ssize_t Write(const void *buff, off_t offset, size_t blen);
+  virtual int Write(XrdSfsAio *aiop);
+  virtual int Fsync(void);
+  virtual int Ftruncate(unsigned long long);
+
+protected:
+  XrdCephOss *m_cephoss  = nullptr;
+  XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
+};
+
+#endif /* __XRD_CEPH_OSS_READV_FILE_HH__ */

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -50,6 +50,8 @@
 
 #include "XrdCeph/XrdCephPosix.hh"
 
+#include "XrdSfs/XrdSfsFlags.hh" // for the OFFLINE flag status 
+
 /// small structs to store file metadata
 struct CephFile {
   std::string name;

--- a/src/XrdCeph/XrdCephPosix.hh
+++ b/src/XrdCeph/XrdCephPosix.hh
@@ -41,7 +41,8 @@
   // ensure that 
   //   extern XrdOucTrace XrdCephTrace; 
   // is in the cc file where you want to log // << std::endl
-  #define LOGCEPH(x) {std::stringstream _s; _s << x;   XrdCephTrace.Beg(); std::clog << _s.str() ; XrdCephTrace.End(); _s.clear();}
+  //#define LOGCEPH(x) {std::stringstream _s; _s << x;   XrdCephTrace.Beg(); std::clog << _s.str() ; XrdCephTrace.End(); _s.clear();}
+  #define LOGCEPH(x) {std::stringstream _s; _s << x;  std::clog << _s.str() << std::endl; _s.clear(); }
 #else 
   #define LOGCEPH(x) 
 #endif 

--- a/src/XrdCeph/XrdCephPosix.hh
+++ b/src/XrdCeph/XrdCephPosix.hh
@@ -35,6 +35,17 @@
 #include <XrdOuc/XrdOucEnv.hh>
 #include <XrdSys/XrdSysXAttr.hh>
 
+// simple logging for XrdCeph buffering code
+#define XRDCEPHLOGLEVEL 1
+#ifdef XRDCEPHLOGLEVEL 
+  // ensure that 
+  //   extern XrdOucTrace XrdCephTrace; 
+  // is in the cc file where you want to log // << std::endl
+  #define LOGCEPH(x) {std::stringstream _s; _s << x;   XrdCephTrace.Beg(); std::clog << _s.str() ; XrdCephTrace.End(); _s.clear();}
+#else 
+  #define LOGCEPH(x) 
+#endif 
+
 class XrdSfsAio;
 typedef void(AioCB)(XrdSfsAio*, size_t);
 


### PR DESCRIPTION
Implementation of a non-async (non-aio) buffering layer for XrdCeph to allow for buffered Read and Write requests.  Buffering is added using a decorator style on top of the XrdCephOss class. Future development will include fully async functionality. 
This is needed to avoid passing the 1MiB requests from XrdTPC (http) requests directly into ceph. 
(I've set base to be master, but it might be better to keep this in a deliberately separate branch for a while - but I didn't work out how to do that). 