### PR TITLE
Set -std flag to c++14

### DIFF
--- a/cmake/XRootDOSDefs.cmake
+++ b/cmake/XRootDOSDefs.cmake
@@ -11,7 +11,7 @@ set( LIBRARY_PATH_PREFIX "lib" )
 # GCC
 #-------------------------------------------------------------------------------
 if( CMAKE_COMPILER_IS_GNUCXX )
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror" )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter" )
   # gcc 4.1 is retarded


### PR DESCRIPTION
Hi Ian, 

This is a change needed for compiling xroot-ceph with the same flag as the main XRootD code. 

https://wiki.e-science.cclrc.ac.uk/web1/bin/view/EScienceInternal/CompilingXRootDCeph

Best, 

George