### PR TITLE
XrdCephPosix: Fix 'Offline' file status

### DIFF
--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -1010,6 +1010,11 @@ int ceph_posix_fstat(int fd, struct stat *buf) {
     if (rc != 0) {
       return -rc;
     }
+    // XRootD assumes an 'offline' file if st_dev and st_ino
+    // are zero. Set to non-zero (meaningful) values to avoid this.
+    std::hash<std::string> strHash;
+    buf->st_dev = static_cast<dev_t>(strHash(fr->pool));
+    buf->st_ino = static_cast<ino_t>(strHash(fr->name));
     buf->st_mtime = buf->st_atime;
     buf->st_ctime = buf->st_atime;
     buf->st_mode = 0666 | S_IFREG;
@@ -1041,6 +1046,11 @@ int ceph_posix_stat(XrdOucEnv* env, const char *pathname, struct stat *buf) {
       return -rc;
     }
   }
+  // XRootD assumes an 'offline' file if st_dev and st_ino
+  // are zero. Set to non-zero (meaningful) values to avoid this.
+  std::hash<std::string> strHash;
+  buf->st_dev = static_cast<dev_t>(strHash(file.pool));
+  buf->st_ino = static_cast<ino_t>(strHash(file.name));
   buf->st_mtime = buf->st_atime;
   buf->st_ctime = buf->st_atime;
   buf->st_mode = 0666 | S_IFREG;


### PR DESCRIPTION
XRootD assumes a file is 'Offline' if the st_dev and st_ino
members returned via a stat are set to zero (defaults).
Workflows may use the 'Offline' flag, so it is important
that it is correct. Since Ceph object store is disk-based,
it is sufficient to default st_dev and st_ino to non-zero
values, such that XRootD determines a file to be 'Online';
the hashes of pool and file names are used to calculate more
meaningful values.

Note:
 - The values used for st_dev and st_ino are not necessarily
   those returned by the hash function, due to the type
   conversion.

See:
https://github.com/xrootd/xrootd/blob/master/src/XrdSfs/XrdSfsFlags.hh#L96