### PR TITLE
cephnamelib

### DIFF
--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -128,19 +128,26 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
        if (!strncmp(var, "ceph.namelib", 12)) {
          var = Config.GetWord();
          if (var) {
+           std::string libname = var;
            // Warn in case parameters were givne
            char parms[1040];
+           bool hasParms{false};
            if (!Config.GetRest(parms, sizeof(parms)) || parms[0]) {
-             Eroute.Emsg("Config", "namelib parameters will be ignored");
+              hasParms = true;
            }
            // Load name lib
-           XrdOucN2NLoader n2nLoader(&Eroute,configfn,NULL,NULL,NULL);
-           g_namelib = n2nLoader.Load(var, XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
+           if (hasParms) {
+             XrdOucN2NLoader  n2nLoader(&Eroute,configfn,parms,NULL,NULL);
+             g_namelib = n2nLoader.Load(libname.c_str(), XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
+           } else {
+             XrdOucN2NLoader  n2nLoader(&Eroute,configfn,NULL,NULL,NULL);
+             g_namelib = n2nLoader.Load(libname.c_str(), XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
+           }
            if (!g_namelib) {
              Eroute.Emsg("Config", "Unable to load library given in ceph.namelib : %s", var);
            }
          } else {
-           Eroute.Emsg("Config", "Missing value for ceph.namelib in config file", configfn);
+           Eroute.Emsg("Config", "Missing value for ceph.namelib in config file ", configfn);
            return 1;
          }
        }

--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -136,13 +136,8 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
               hasParms = true;
            }
            // Load name lib
-           if (hasParms) {
-             XrdOucN2NLoader  n2nLoader(&Eroute,configfn,parms,NULL,NULL);
-             g_namelib = n2nLoader.Load(libname.c_str(), XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
-           } else {
-             XrdOucN2NLoader  n2nLoader(&Eroute,configfn,NULL,NULL,NULL);
-             g_namelib = n2nLoader.Load(libname.c_str(), XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
-           }
+           XrdOucN2NLoader  n2nLoader(&Eroute,configfn,(hasParms?parms:""),NULL,NULL);
+           g_namelib = n2nLoader.Load(libname.c_str(), XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
            if (!g_namelib) {
              Eroute.Emsg("Config", "Unable to load library given in ceph.namelib : %s", var);
            }

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -425,10 +425,10 @@ void fillCephFile(const char *path, XrdOucEnv *env, CephFile &file) {
   size_t colonPos = spath.find(':');
   if (std::string::npos == colonPos) {
     // deal with name translation
-    // translateFileName(file.name, spath);
+    file.name = spath;
     fillCephFileParams("", env, file);
   } else {
-    // translateFileName(file.name, spath.substr(colonPos+1));
+    file.name = spath.substr(colonPos+1);
     fillCephFileParams(spath.substr(0, colonPos), env, file);
   }
 }

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -400,11 +400,11 @@ void translateFileName(std::string &physName, std::string logName){
       logwrapper((char*)"ceph_namelib : failed to translate %s using namelib plugin, using it as is", logName.c_str());
       physName = logName;
     } else {
-      logwrapper((char*)"ceph_namelib : translated %s to %s", logName.c_str(), physCName);
+      //logwrapper((char*)"ceph_namelib : translated %s to %s", logName.c_str(), physCName);
       physName = physCName;
     }
   } else {
-      logwrapper((char*)"ceph_namelib : No mapping done");
+    //logwrapper((char*)"ceph_namelib : No mapping done");
     physName = logName;
   }
 }

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -400,9 +400,11 @@ void translateFileName(std::string &physName, std::string logName){
       logwrapper((char*)"ceph_namelib : failed to translate %s using namelib plugin, using it as is", logName.c_str());
       physName = logName;
     } else {
+      logwrapper((char*)"ceph_namelib : translated %s to %s", logName.c_str(), physCName);
       physName = physCName;
     }
   } else {
+      logwrapper((char*)"ceph_namelib : No mapping done");
     physName = logName;
   }
 }
@@ -417,14 +419,16 @@ void fillCephFile(const char *path, XrdOucEnv *env, CephFile &file) {
   // If env is null or no entry is found for what is missing, defaults are
   // applied. These defaults are initially set to 'admin', 'default', 1, 4MB and 4MB
   // but can be changed via a call to ceph_posix_set_defaults
-  std::string spath = path;
+  std::string spath {path};
+  // If namelib is specified, apply translation to the whole path (which might include pool, etc)
+  translateFileName(spath,path);
   size_t colonPos = spath.find(':');
   if (std::string::npos == colonPos) {
     // deal with name translation
-    translateFileName(file.name, spath);
+    // translateFileName(file.name, spath);
     fillCephFileParams("", env, file);
   } else {
-    translateFileName(file.name, spath.substr(colonPos+1));
+    // translateFileName(file.name, spath.substr(colonPos+1));
     fillCephFileParams(spath.substr(0, colonPos), env, file);
   }
 }

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -400,7 +400,7 @@ void translateFileName(std::string &physName, std::string logName){
       logwrapper((char*)"ceph_namelib : failed to translate %s using namelib plugin, using it as is", logName.c_str());
       physName = logName;
     } else {
-      //logwrapper((char*)"ceph_namelib : translated %s to %s", logName.c_str(), physCName);
+      logwrapper((char*)"ceph_namelib : translated %s to %s", logName.c_str(), physCName);
       physName = physCName;
     }
   } else {


### PR DESCRIPTION
Allow ceph.namelib to be able to accept parameters via its directive, as used in the oss and pss cases.
The latest commit also provides a fix, ensuring the correct filename is passed to the CephFile instance.