### PR TITLE
XRD-22 Set correct filename for  CephFile

### DIFF
--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -425,10 +425,10 @@ void fillCephFile(const char *path, XrdOucEnv *env, CephFile &file) {
   size_t colonPos = spath.find(':');
   if (std::string::npos == colonPos) {
     // deal with name translation
-    // translateFileName(file.name, spath);
+    file.name = spath;
     fillCephFileParams("", env, file);
   } else {
-    // translateFileName(file.name, spath.substr(colonPos+1));
+    file.name = spath.substr(colonPos+1);
     fillCephFileParams(spath.substr(0, colonPos), env, file);
   }
 }


### PR DESCRIPTION
A regression in previous commit meant that the filename was not correctly passed
to the CephFile instance. This fix ensures that the filename is set correctly when XrdCeph receives a path.
Replaces PR#23. 