### PR TITLE
Decreased logging for bufferedIO operations.

### DIFF
--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -43,8 +43,8 @@ ssize_t CephIOAdapterRaw::write(off64_t offset,size_t count) {
     auto end = std::chrono::steady_clock::now();
     auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
 
-    BUFLOG("CephIOAdapterRaw::write fd:" << m_fd << " " << rc << " "
-              <<  offset << " " << count << " " << rc << " " << int_ms.count() );
+    // BUFLOG("CephIOAdapterRaw::write fd:" << m_fd << " " << rc << " "
+    //           <<  offset << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc < 0) return rc;
     m_stats_write_longest = std::max(m_stats_write_longest,int_ms.count()); 
@@ -75,8 +75,8 @@ ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     m_stats_read_bytes.fetch_add(rc);
     ++m_stats_read_req;
 
-    BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
-             << " " << count << " " << rc << " " << int_ms.count() );
+    // BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
+    //          << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc>=0) {
       m_bufferdata->setLength(rc);


### PR DESCRIPTION
Reduced printouts. Only summary stats now produced, rather than the logging per read.