### PR TITLE
disable posc

### DIFF
--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -98,6 +98,8 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
    int NoGo = 0;
    XrdOucEnv myEnv;
    XrdOucStream Config(&Eroute, getenv("XRDINSTANCE"), &myEnv, "=====> ");
+   //disable posc  
+   XrdOucEnv::Export("XRDXROOTD_NOPOSC", "1");
    // If there is no config file, nothing to be done
    if (configfn && *configfn) {
      // Try to open the configuration file.


### PR DESCRIPTION
posc is disabled for proxies, but not for a unified setup. XrdCeph does not support the posc flag as it misinterprets objects as folders