### PR TITLE
Vector read: refactoring

### DIFF
--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -128,19 +128,21 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
        if (!strncmp(var, "ceph.namelib", 12)) {
          var = Config.GetWord();
          if (var) {
+           std::string libname = var;
            // Warn in case parameters were givne
            char parms[1040];
+           bool hasParms{false};
            if (!Config.GetRest(parms, sizeof(parms)) || parms[0]) {
-             Eroute.Emsg("Config", "namelib parameters will be ignored");
+              hasParms = true;
            }
            // Load name lib
-           XrdOucN2NLoader n2nLoader(&Eroute,configfn,NULL,NULL,NULL);
-           g_namelib = n2nLoader.Load(var, XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
+           XrdOucN2NLoader  n2nLoader(&Eroute,configfn,(hasParms?parms:""),NULL,NULL);
+           g_namelib = n2nLoader.Load(libname.c_str(), XrdVERSIONINFOVAR(XrdOssGetStorageSystem), NULL);
            if (!g_namelib) {
              Eroute.Emsg("Config", "Unable to load library given in ceph.namelib : %s", var);
            }
          } else {
-           Eroute.Emsg("Config", "Missing value for ceph.namelib in config file", configfn);
+           Eroute.Emsg("Config", "Missing value for ceph.namelib in config file ", configfn);
            return 1;
          }
        }

--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -94,6 +94,7 @@ XrdCephOss::~XrdCephOss() {
 
 // declared and used in XrdCephPosix.cc
 extern unsigned int g_maxCephPoolIdx;
+extern unsigned int g_ReadVBufSize;
 int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
    int NoGo = 0;
    XrdOucEnv myEnv;
@@ -125,6 +126,23 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
            return 1;
          }
        }
+
+       if (!strncmp(var, "ceph.readvbufsize", 17)) {
+         var = Config.GetWord();
+         if (var) {
+           unsigned long value = strtoul(var,0, 10);
+           if (value > 0) {
+             g_ReadVBufSize = value;
+           } else {
+             Eroute.Emsg("Config", "Invalid value for ceph.readvbufsize in config file (must be > 0)", configfn, var);
+             return 1;
+           }
+         } else {
+           Eroute.Emsg("Config", "Missing value for ceph.readvbufsize in config file", configfn);
+           return 1;
+         }
+       }
+
        if (!strncmp(var, "ceph.namelib", 12)) {
          var = Config.GetWord();
          if (var) {

--- a/src/XrdCeph/XrdCephOssFile.cc
+++ b/src/XrdCeph/XrdCephOssFile.cc
@@ -91,21 +91,21 @@ ssize_t XrdCephOssFile::process_block(off_t block_start, size_t block_len, std::
       buf = new char[READV_BUFFER_SIZE];
     } catch(std::bad_alloc&) {
        //FIXME: use log function
-       printf("Can not allocate memory for readv buffer! Exiting\n");
+       fprintf(stderr, "Can not allocate memory for readv buffer! Exiting\n");
        return -ENOMEM;
     }
-    //printf("Going to read %ld,%ld \n", block_len, block_start);
+    //fprintf(stderr, "Going to read %ld,%ld \n", block_len, block_start);
     real_data_read = ceph_async_read(m_fd, (void*) buf, block_len, block_start);
     if (real_data_read < (ssize_t)block_len) {
       //FIXME: use log function
-      printf("Expected %lu bytes, got %ld. Exiting\n", block_len, real_data_read);
+      fprintf(stderr, "Expected %lu bytes, got %ld. Exiting\n", block_len, real_data_read);
       delete[] buf;
       return -ESPIPE;
     }
     for (int i: chunks_to_read) {
       ptr = buf;
       ptr += readV[i].offset - block_start;
-      //printf("Extracting chunk %d, ptr_pos: %lld, chunks size: %d, offset: %lld, data_read: %ld\n", i, readV[i].offset - block_start, readV[i].size, readV[i].offset, real_data_read);
+      //fprintf(stderr, "Extracting chunk %d, ptr_pos: %lld, chunks size: %d, offset: %lld, data_read: %ld\n", i, readV[i].offset - block_start, readV[i].size, readV[i].offset, real_data_read);
       memcpy(readV[i].data, ptr, readV[i].size);
       data_read += readV[i].size;
     }
@@ -144,7 +144,7 @@ ssize_t XrdCephOssFile::ReadV(XrdOucIOVec *readV, int n) {
     //Now we know updated block's start and end, let's update its lengt
     new_block_len = new_end - new_block_start + 1;
 
-    //printf("block_start: %ld, block_len: %ld, new_block_start: %ld, new_block_len: %ld , offset: %lld, size: %d, i: %d\n", block_start, block_len, new_block_start, new_block_len, readV[i].offset, readV[i].size, i);
+    //fprintf(stderr, "block_start: %ld, block_len: %ld, new_block_start: %ld, new_block_len: %ld , offset: %lld, size: %d, i: %d\n", block_start, block_len, new_block_start, new_block_len, readV[i].offset, readV[i].size, i);
     if (new_block_len > READV_BUFFER_SIZE && block_len > 0) {
         block_data_read = process_block(block_start, block_len, chunks_to_read, readV);
         if (block_data_read > 0) {
@@ -152,7 +152,7 @@ ssize_t XrdCephOssFile::ReadV(XrdOucIOVec *readV, int n) {
           ceph_read_count++;
         } else {
           //FIXME: use log function
-          printf("Error while reading block at %ld, got %ld\n", block_start, block_data_read);
+          fprintf(stderr, "Error while reading block at %ld, got %ld\n", block_start, block_data_read);
           return block_data_read;
         }
         chunks_to_read.clear();
@@ -173,12 +173,12 @@ ssize_t XrdCephOssFile::ReadV(XrdOucIOVec *readV, int n) {
       ceph_read_count++;
     } else {
       //FIXME: use log function
-      printf("Error while reading block at %ld, got %ld\n", block_start, block_data_read);
+      fprintf(stderr, "Error while reading block at %ld, got %ld\n", block_start, block_data_read);
       return block_data_read;
     }
   }
   //FIXME: use log function
-  printf("%d reads issued for %d blocks\n", ceph_read_count, n);
+  fprintf(stderr, "%d reads issued for %d blocks\n", ceph_read_count, n);
 
   return data_read;
 }

--- a/src/XrdCeph/XrdCephOssFile.cc
+++ b/src/XrdCeph/XrdCephOssFile.cc
@@ -38,7 +38,7 @@
 
 extern XrdSysError XrdCephEroute;
 
-#define READV_BUFFER_SIZE 16777216
+#define READV_BUFFER_SIZE 4194304
 
 XrdCephOssFile::XrdCephOssFile(XrdCephOss *cephOss) : m_fd(-1), m_cephOss(cephOss) {}
 

--- a/src/XrdCeph/XrdCephOssFile.cc
+++ b/src/XrdCeph/XrdCephOssFile.cc
@@ -80,83 +80,105 @@ ssize_t XrdCephOssFile::ReadRaw(void *buff, off_t offset, size_t blen) {
 }
 
 ssize_t XrdCephOssFile::process_block(off_t block_start, size_t block_len, std::vector<int> chunks_to_read, XrdOucIOVec *readV) {
-  char * buf = new char[READV_BUFFER_SIZE];
-  char *ptr;
+  char *ptr, *buf;
   ssize_t data_read, real_data_read;
   data_read = 0;
-  printf("processing block %lu %lu\n", block_start, block_len);
   if (chunks_to_read.size() == 1) {
     int idx = chunks_to_read[0];
     data_read = ceph_async_read(m_fd, (void*)readV[idx].data, readV[idx].size, readV[idx].offset);
   } else {
+    try {
+      buf = new char[READV_BUFFER_SIZE];
+    } catch(std::bad_alloc&) {
+       //FIXME: use log function
+       printf("Can not allocate memory for readv buffer! Exiting\n");
+       return -ENOMEM;
+    }
+    //printf("Going to read %ld,%ld \n", block_len, block_start);
     real_data_read = ceph_async_read(m_fd, (void*) buf, block_len, block_start);
-    printf("read %ld bytes\n", real_data_read);
     if (real_data_read < (ssize_t)block_len) {
-      //log("Requested %lu bytes, got %lu!\n", block_len, data_read);
-      return -data_read;
+      //FIXME: use log function
+      printf("Expected %lu bytes, got %ld. Exiting\n", block_len, real_data_read);
+      delete[] buf;
+      return -ESPIPE;
     }
     for (int i: chunks_to_read) {
       ptr = buf;
       ptr += readV[i].offset - block_start;
+      //printf("Extracting chunk %d, ptr_pos: %lld, chunks size: %d, offset: %lld, data_read: %ld\n", i, readV[i].offset - block_start, readV[i].size, readV[i].offset, real_data_read);
       memcpy(readV[i].data, ptr, readV[i].size);
       data_read += readV[i].size;
-      printf("Extracting block %d, data read %ld\n",i,  data_read);
     }
+    delete[] buf;
   }
-  delete[] buf;
-  printf("returning  %ld\n", data_read);
   return data_read;
 }
 
 ssize_t XrdCephOssFile::ReadV(XrdOucIOVec *readV, int n) {
-  ssize_t data_read, chunks_data_read, block_start, block_len, tlen;
+  ssize_t data_read, block_data_read, block_start, block_len, cur_end, new_end;
+  ssize_t new_block_start, new_block_len;
   std::vector<int> chunks_to_read;
+  int ceph_read_count = 0;
   block_start = -1;
   block_len = 0;
   data_read = 0;
-  printf("starting readv\n");
+  //printf("Readv started\n");
   for (int i = 0; i < n; i++) {
-    printf("start: %lu, len: %lu, rstart: %lld, rlen: %d\n", block_start, block_len, readV[i].offset, readV[i].size);
-    if (block_start > 0) {
-      tlen = readV[i].offset + readV[i].size - block_start;
-      if (tlen > READV_BUFFER_SIZE || block_len > READV_BUFFER_SIZE || readV[i].offset < block_start) {
-        chunks_data_read = process_block(block_start, block_len, chunks_to_read, readV);
-        if (chunks_data_read > 0) {
-          data_read += chunks_data_read;
+    //Calculate new block borders, after a chunk will be added to the block
+    //To do so first calculate end of current block and end of chunk
+    cur_end = block_start + block_len - 1;
+    new_end = readV[i].offset + readV[i].size - 1;
+
+    //Update block start if new chunk's start is preced it.
+    if (readV[i].offset < block_start or block_start < 0) {
+      new_block_start = readV[i].offset;
+    } else {
+      new_block_start = block_start;
+    }
+
+    //Update block end if chunk's end is greater than the block's one
+    if (cur_end > new_end) {
+      new_end = cur_end;
+    }
+
+    //Now we know updated block's start and end, let's update its lengt
+    new_block_len = new_end - new_block_start + 1;
+
+    //printf("block_start: %ld, block_len: %ld, new_block_start: %ld, new_block_len: %ld , offset: %lld, size: %d, i: %d\n", block_start, block_len, new_block_start, new_block_len, readV[i].offset, readV[i].size, i);
+    if (new_block_len > READV_BUFFER_SIZE && block_len > 0) {
+        block_data_read = process_block(block_start, block_len, chunks_to_read, readV);
+        if (block_data_read > 0) {
+          data_read += block_data_read;
+          ceph_read_count++;
         } else {
-          //log("Error while reading block at %ul, got %d\n", block_start, chunks_data_read);
-          printf("Emergency exit, %ld bytes\n", chunks_data_read);
-          return chunks_data_read;
+          //FIXME: use log function
+          printf("Error while reading block at %ld, got %ld\n", block_start, block_data_read);
+          return block_data_read;
         }
-        block_start = -1;
-        block_len = 0;
-        tlen = readV[i].offset + readV[i].size - block_start;
         chunks_to_read.clear();
-      }
-      chunks_to_read.push_back(i);
-      if (block_start < 0) {
         block_start = readV[i].offset;
-      }
-      if (tlen > block_len) {
-        block_len = tlen;
-      }
+        block_len = readV[i].size;
     } else {
-      block_start = readV[i].offset;
-      block_len = readV[i].size;
-      chunks_to_read.push_back(i);
+      block_start = new_block_start;
+      block_len = new_block_len;
+    }
+    chunks_to_read.push_back(i);
+  }
+
+  //Extract chunks from the last block
+  if (chunks_to_read.size() > 0) {
+    block_data_read = process_block(block_start, block_len, chunks_to_read, readV);
+    if (block_data_read > 0) {
+      data_read += block_data_read;
+      ceph_read_count++;
+    } else {
+      //FIXME: use log function
+      printf("Error while reading block at %ld, got %ld\n", block_start, block_data_read);
+      return block_data_read;
     }
   }
-  if (block_len > 0) {
-    chunks_data_read = process_block(block_start, block_len, chunks_to_read, readV);
-    if (chunks_data_read > 0) {
-      data_read += chunks_data_read;
-    } else {
-      //log("Error while reading block at %ul, got %d\n", block_start, chunks_data_read);
-      printf("Emergency exit, %ld bytes\n", chunks_data_read);
-      return chunks_data_read;
-    }
-  }
-  printf("All read %ld bytes\n", data_read);
+  //FIXME: use log function
+  printf("%d reads issued for %d blocks\n", ceph_read_count, n);
 
   return data_read;
 }

--- a/src/XrdCeph/XrdCephOssFile.cc
+++ b/src/XrdCeph/XrdCephOssFile.cc
@@ -38,7 +38,7 @@
 
 extern XrdSysError XrdCephEroute;
 
-#define READV_BUFFER_SIZE 4194304
+unsigned int g_ReadVBufSize = DEF_READV_BUFFER_SIZE;
 
 XrdCephOssFile::XrdCephOssFile(XrdCephOss *cephOss) : m_fd(-1), m_cephOss(cephOss) {}
 
@@ -88,7 +88,7 @@ ssize_t XrdCephOssFile::process_block(off_t block_start, size_t block_len, std::
     data_read = ceph_async_read(m_fd, (void*)readV[idx].data, readV[idx].size, readV[idx].offset);
   } else {
     try {
-      buf = new char[READV_BUFFER_SIZE];
+      buf = new char[g_ReadVBufSize];
     } catch(std::bad_alloc&) {
        //FIXME: use log function
        fprintf(stderr, "Can not allocate memory for readv buffer! Exiting\n");
@@ -145,7 +145,7 @@ ssize_t XrdCephOssFile::ReadV(XrdOucIOVec *readV, int n) {
     new_block_len = new_end - new_block_start + 1;
 
     //fprintf(stderr, "block_start: %ld, block_len: %ld, new_block_start: %ld, new_block_len: %ld , offset: %lld, size: %d, i: %d\n", block_start, block_len, new_block_start, new_block_len, readV[i].offset, readV[i].size, i);
-    if (new_block_len > READV_BUFFER_SIZE && block_len > 0) {
+    if (new_block_len > g_ReadVBufSize && block_len > 0) {
         block_data_read = process_block(block_start, block_len, chunks_to_read, readV);
         if (block_data_read > 0) {
           data_read += block_data_read;

--- a/src/XrdCeph/XrdCephOssFile.hh
+++ b/src/XrdCeph/XrdCephOssFile.hh
@@ -28,6 +28,8 @@
 #include "XrdOss/XrdOss.hh"
 #include "XrdCeph/XrdCephOss.hh"
 
+#include <vector>
+
 //------------------------------------------------------------------------------
 //! This class implements XrdOssDF interface for usage with a CEPH storage.
 //!
@@ -70,6 +72,7 @@ public:
 
 private:
 
+  virtual ssize_t process_block(off_t block_start, size_t block_len, std::vector<int> chunks_to_read, XrdOucIOVec *readV);
   int m_fd;
   XrdCephOss *m_cephOss;
 

--- a/src/XrdCeph/XrdCephOssFile.hh
+++ b/src/XrdCeph/XrdCephOssFile.hh
@@ -30,6 +30,8 @@
 
 #include <vector>
 
+#define DEF_READV_BUFFER_SIZE 4194304
+
 //------------------------------------------------------------------------------
 //! This class implements XrdOssDF interface for usage with a CEPH storage.
 //!

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -473,9 +473,11 @@ void translateFileName(std::string &physName, std::string logName){
       logwrapper((char*)"ceph_namelib : failed to translate %s using namelib plugin, using it as is", logName.c_str());
       physName = logName;
     } else {
+      logwrapper((char*)"ceph_namelib : translated %s to %s", logName.c_str(), physCName);
       physName = physCName;
     }
   } else {
+    //logwrapper((char*)"ceph_namelib : No mapping done");
     physName = logName;
   }
 }
@@ -490,14 +492,16 @@ void fillCephFile(const char *path, XrdOucEnv *env, CephFile &file) {
   // If env is null or no entry is found for what is missing, defaults are
   // applied. These defaults are initially set to 'admin', 'default', 1, 4MB and 4MB
   // but can be changed via a call to ceph_posix_set_defaults
-  std::string spath = path;
+  std::string spath {path};
+  // If namelib is specified, apply translation to the whole path (which might include pool, etc)
+  translateFileName(spath,path);
   size_t colonPos = spath.find(':');
   if (std::string::npos == colonPos) {
     // deal with name translation
-    translateFileName(file.name, spath);
+    // translateFileName(file.name, spath);
     fillCephFileParams("", env, file);
   } else {
-    translateFileName(file.name, spath.substr(colonPos+1));
+    // translateFileName(file.name, spath.substr(colonPos+1));
     fillCephFileParams(spath.substr(0, colonPos), env, file);
   }
 }

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -498,10 +498,10 @@ void fillCephFile(const char *path, XrdOucEnv *env, CephFile &file) {
   size_t colonPos = spath.find(':');
   if (std::string::npos == colonPos) {
     // deal with name translation
-    // translateFileName(file.name, spath);
+    file.name = spath;
     fillCephFileParams("", env, file);
   } else {
-    // translateFileName(file.name, spath.substr(colonPos+1));
+    file.name = spath.substr(colonPos+1);
     fillCephFileParams(spath.substr(0, colonPos), env, file);
   }
 }

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -47,8 +47,11 @@
 #include "XrdSys/XrdSysPthread.hh"
 #include "XrdOuc/XrdOucName2Name.hh"
 #include "XrdSys/XrdSysPlatform.hh"
+#include "XrdOuc/XrdOucIOVec.hh"
 
 #include "XrdCeph/XrdCephPosix.hh"
+
+typedef std::tuple<librados::AioCompletion*, ceph::bufferlist*, char*> ReadOpData;
 
 /// small structs to store file metadata
 struct CephFile {
@@ -223,6 +226,76 @@ static void logwrapper(char* format, ...) {
   (*g_logfunc)(format, arg);
   va_end(arg);
 }
+
+//class to handle multiple async read requests
+class bulkAioRead {
+  public:
+  bulkAioRead(librados::IoCtx *ct) {
+    context = ct;
+  };
+
+  ~bulkAioRead() {
+    for (ReadOpData i: operations){
+      std::get<0>(i)->release();
+      delete std::get<1>(i);
+    }
+  };
+
+  int addRequest(const char* fname, ssize_t size, off64_t offset, char* out_buf) {
+     librados::AioCompletion* cmpl;
+     ceph::bufferlist* bl;
+     ReadOpData tup;
+
+     cmpl = librados::Rados::aio_create_completion();
+     if (0 == cmpl) {
+       logwrapper((char*)"Can not create completion for read (%lu, %lu)", offset, size);
+       return -1;
+     }
+
+     try {
+       bl = new ceph::bufferlist();
+     } catch (std::bad_alloc&) {
+       logwrapper((char*)"Can not allocate buffer for read (%lu, %lu)", offset, size);
+       cmpl->release();
+       return -1;
+     }
+
+     tup = std::make_tuple(cmpl, bl, out_buf);
+     operations.push_back(tup);
+
+     return context->aio_read(fname, cmpl, bl, size, offset);
+  };
+
+  void wait_for_complete() {
+    for (ReadOpData i: operations) {
+      std::get<0>(i)->wait_for_complete();
+    }
+  };
+
+  ssize_t get_results() {
+    ceph::bufferlist* bl;
+    librados::AioCompletion* cmpl;
+    char *buf;
+    ssize_t res = 0;
+    int rc;
+    for (ReadOpData i: operations) {
+      cmpl = std::get<0>(i);
+      bl = std::get<1>(i);
+      buf = std::get<2>(i);
+      rc = cmpl->get_return_value();
+      if (rc < 0) {
+        return rc;
+      }
+      bl->begin().copy(rc, buf);
+      res += rc;
+    }
+    return res;
+  };
+
+  private:
+  librados::IoCtx* context;
+  std::list<ReadOpData> operations;
+};
 
 /// simple integer parsing, to be replaced by std::stoll when C++11 can be used
 static unsigned long long int stoull(const std::string &s) {
@@ -876,6 +949,87 @@ ssize_t ceph_aio_write(int fd, XrdSfsAio *aiop, AioCB *cb) {
     ::gettimeofday(&fr->lastAsyncSubmission, nullptr);
     fr->bytesAsyncWritePending+=count;
     return rc;
+  } else {
+    return -EBADF;
+  }
+}
+
+ssize_t ceph_async_read(int fd, void *buff, size_t blen, off_t offset)  {
+  CephFileRef* fr = getFileRef(fd);
+  if (fr) {
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
+    if ((fr->flags & O_WRONLY) != 0) {
+      return -EBADF;
+    }
+
+    const unsigned int block_size = fr->objectSize;
+
+    int rc;
+    ssize_t end_block, req_len, chunk_start, chunk_len, read_bytes;
+    size_t buf_pos;
+    unsigned int start_block;
+    char * fname;
+    char * buf_ptr;
+
+    req_len = blen;
+
+    try {
+      //Extra 18 symbols for stipe object -- 16 digits, dot and null
+      fname = new char[strlen(fr->name.c_str()) + 18];
+    } catch(std::bad_alloc&) {
+      logwrapper( (char*)"Can not allocate data for block filename\n");
+      return -1;
+    }
+
+    librados::IoCtx *ioctx = getIoCtx(*fr);
+    if (0 == ioctx) {
+      errno = EINVAL;
+      delete[] fname;
+      return 0;
+    }
+    bulkAioRead readOp = bulkAioRead(ioctx);
+
+    start_block = offset / block_size;
+    end_block = (offset + req_len - 1) / block_size;
+    buf_ptr = (char*) buff;
+    buf_pos = 0;
+
+    while (start_block <= end_block) {
+      sprintf(fname, "%s.%016x", fr->name.c_str(), start_block);
+      chunk_start = offset % block_size;
+      if (req_len < block_size - chunk_start) {
+        chunk_len = req_len;
+      } else {
+        chunk_len = block_size - chunk_start;
+      }
+
+      //logwrapper((char*)"Going to read %s, %lu %lu\n", fname, chunk_len, chunk_start);
+      rc = readOp.addRequest(fname, chunk_len, chunk_start, buf_ptr);
+      if (rc < 0) {
+        logwrapper((char*)"Unable to submit async read request of file %s: rc=%d\n", fname, rc);
+        delete[] fname;
+        return rc;
+      }
+      buf_pos += chunk_len;
+      if (buf_pos > blen) {
+        logwrapper((char*)"Internal bug! Attempt to read %lu data for block (%lu, %lu)\n", buf_pos, offset, blen);
+        delete[] fname;
+      }
+      buf_ptr += chunk_len;
+
+      start_block++;
+      offset = start_block*block_size;
+      req_len = req_len - chunk_len;
+    }
+
+    read_bytes = 0;
+    readOp.wait_for_complete();
+    read_bytes = readOp.get_results();
+    delete [] fname;
+    XrdSysMutexHelper lock(fr->statsMutex);
+    fr->rdcount += 1;
+    return read_bytes;
   } else {
     return -EBADF;
   }

--- a/src/XrdCeph/XrdCephPosix.hh
+++ b/src/XrdCeph/XrdCephPosix.hh
@@ -35,6 +35,8 @@
 #include <XrdOuc/XrdOucEnv.hh>
 #include <XrdSys/XrdSysXAttr.hh>
 
+#include "XrdOuc/XrdOucIOVec.hh"
+
 class XrdSfsAio;
 typedef void(AioCB)(XrdSfsAio*, size_t);
 
@@ -48,6 +50,7 @@ off64_t ceph_posix_lseek64(int fd, off64_t offset, int whence);
 ssize_t ceph_posix_write(int fd, const void *buf, size_t count);
 ssize_t ceph_posix_pwrite(int fd, const void *buf, size_t count, off64_t offset);
 ssize_t ceph_aio_write(int fd, XrdSfsAio *aiop, AioCB *cb);
+ssize_t ceph_async_read(int fd, void *buff, size_t blen, off_t offset);
 ssize_t ceph_posix_read(int fd, void *buf, size_t count);
 ssize_t ceph_posix_pread(int fd, void *buf, size_t count, off64_t offset);
 ssize_t ceph_aio_read(int fd, XrdSfsAio *aiop, AioCB *cb);


### PR DESCRIPTION
It seems that removing rados striper and reading directly from ceph objects can improve performance significantly. We use asynchronous read from ceph, to handle multiple such reads a new class bulkAioRead is introduced. We also use "local" buffering: we try to accumulate chunks of the original readv request into a block, read the block and then extract chunks from the block.