### PR TITLE
Vector read nonstriper

### DIFF
--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -42,6 +42,8 @@
 #include "XrdCeph/XrdCephOssDir.hh"
 #include "XrdCeph/XrdCephOssFile.hh"
 
+#include <chrono>
+
 XrdVERSIONINFO(XrdOssGetStorageSystem, XrdCephOss);
 
 XrdSysError XrdCephEroute(0);

--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -66,6 +66,7 @@ static void logwrapper(char *format, va_list argp) {
 /// populated in case of ceph.namelib entry in the config file
 /// used in XrdCephPosix
 extern XrdOucName2Name *g_namelib;
+extern unsigned int g_ReadVBufSize;
 
 extern "C"
 {
@@ -135,6 +136,23 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
            return 1;
          }
        }
+
+       if (!strncmp(var, "ceph.readvbufsize", 17)) {
+         var = Config.GetWord();
+         if (var) {
+           unsigned long value = strtoul(var,0, 10);
+           if (value > 0) {
+             g_ReadVBufSize = value;
+           } else {
+             Eroute.Emsg("Config", "Invalid value for ceph.readvbufsize in config file (must be > 0)", configfn, var);
+             return 1;
+           }
+         } else {
+           Eroute.Emsg("Config", "Missing value for ceph.readvbufsize in config file", configfn);
+           return 1;
+         }
+       }
+
        if (!strncmp(var, "ceph.namelib", 12)) {
          var = Config.GetWord();
          if (var) {

--- a/src/XrdCeph/XrdCephOss.hh
+++ b/src/XrdCeph/XrdCephOss.hh
@@ -49,6 +49,8 @@
 //! have a default and they are different, the behavior is not defined.
 //! In case one of the two only has a default, it will be applied for both plugins.
 //------------------------------------------------------------------------------
+//
+#define DEF_READV_BUFFER_SIZE 4194304
 
 class XrdCephOss : public XrdOss {
 public:

--- a/src/XrdCeph/XrdCephOssFile.cc
+++ b/src/XrdCeph/XrdCephOssFile.cc
@@ -61,7 +61,7 @@ ssize_t XrdCephOssFile::Read(off_t offset, size_t blen) {
 }
 
 ssize_t XrdCephOssFile::Read(void *buff, off_t offset, size_t blen) {
-  return ceph_posix_pread(m_fd, buff, blen, offset);
+  return ceph_async_read(m_fd, buff, blen, offset);
 }
 
 static void aioReadCallback(XrdSfsAio *aiop, size_t rc) {

--- a/src/XrdCeph/XrdCephOssFile.hh
+++ b/src/XrdCeph/XrdCephOssFile.hh
@@ -28,6 +28,8 @@
 #include "XrdOss/XrdOss.hh"
 #include "XrdCeph/XrdCephOss.hh"
 
+#include <vector>
+
 //------------------------------------------------------------------------------
 //! This class implements XrdOssDF interface for usage with a CEPH storage.
 //!
@@ -60,6 +62,7 @@ public:
   virtual ssize_t Read(off_t offset, size_t blen);
   virtual ssize_t Read(void *buff, off_t offset, size_t blen);
   virtual int     Read(XrdSfsAio *aoip);
+  virtual ssize_t ReadV(XrdOucIOVec *readV, int n);
   virtual ssize_t ReadRaw(void *, off_t, size_t);
   virtual int Fstat(struct stat *buff);
   virtual ssize_t Write(const void *buff, off_t offset, size_t blen);
@@ -69,6 +72,7 @@ public:
 
 private:
 
+  virtual ssize_t process_block(off_t block_start, size_t block_len, std::vector<int> chunks_to_read, XrdOucIOVec *readV);
   int m_fd;
   XrdCephOss *m_cephOss;
 

--- a/src/XrdCeph/XrdCephOssFile.hh
+++ b/src/XrdCeph/XrdCephOssFile.hh
@@ -72,7 +72,7 @@ public:
 
 private:
 
-  virtual ssize_t process_block(off_t block_start, size_t block_len, std::vector<int> chunks_to_read, XrdOucIOVec *readV);
+  virtual ssize_t process_block(off_t block_start, size_t block_len, std::vector<int> chunks_to_read, XrdOucIOVec *readV, char* buf);
   int m_fd;
   XrdCephOss *m_cephOss;
 

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -41,7 +41,6 @@
 #include <sstream>
 #include <sys/xattr.h>
 #include <time.h>
-#include <chrono>
 #include <limits>
 #include <pthread.h>
 #include "XrdSfs/XrdSfsAio.hh"

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -48,8 +48,11 @@
 #include "XrdSys/XrdSysPthread.hh"
 #include "XrdOuc/XrdOucName2Name.hh"
 #include "XrdSys/XrdSysPlatform.hh"
+#include "XrdOuc/XrdOucIOVec.hh"
 
 #include "XrdCeph/XrdCephPosix.hh"
+
+typedef std::tuple<librados::AioCompletion*, ceph::bufferlist*, char*> ReadOpData;
 
 /// small structs to store file metadata
 struct CephFile {
@@ -224,6 +227,76 @@ static void logwrapper(char* format, ...) {
   (*g_logfunc)(format, arg);
   va_end(arg);
 }
+
+//class to handle multiple async read requests
+class bulkAioRead {
+  public:
+  bulkAioRead(librados::IoCtx *ct) {
+    context = ct;
+  };
+
+  ~bulkAioRead() {
+    for (ReadOpData i: operations){
+      std::get<0>(i)->release();
+      delete std::get<1>(i);
+    }
+  };
+
+  int addRequest(const char* fname, ssize_t size, off64_t offset, char* out_buf) {
+     librados::AioCompletion* cmpl;
+     ceph::bufferlist* bl;
+     ReadOpData tup;
+
+     cmpl = librados::Rados::aio_create_completion();
+     if (0 == cmpl) {
+       logwrapper((char*)"Can not create completion for read (%lu, %lu)", offset, size);
+       return -ENOMEM;
+     }
+
+     try {
+       bl = new ceph::bufferlist();
+     } catch (std::bad_alloc&) {
+       logwrapper((char*)"Can not allocate buffer for read (%lu, %lu)", offset, size);
+       cmpl->release();
+       return -ENOMEM;
+     }
+
+     tup = std::make_tuple(cmpl, bl, out_buf);
+     operations.push_back(tup);
+
+     return context->aio_read(fname, cmpl, bl, size, offset);
+  };
+
+  void wait_for_complete() {
+    for (ReadOpData i: operations) {
+      std::get<0>(i)->wait_for_complete();
+    }
+  };
+
+  ssize_t get_results() {
+    ceph::bufferlist* bl;
+    librados::AioCompletion* cmpl;
+    char *buf;
+    ssize_t res = 0;
+    int rc;
+    for (ReadOpData i: operations) {
+      cmpl = std::get<0>(i);
+      bl = std::get<1>(i);
+      buf = std::get<2>(i);
+      rc = cmpl->get_return_value();
+      if (rc < 0) {
+        return rc;
+      }
+      bl->begin().copy(rc, buf);
+      res += rc;
+    }
+    return res;
+  };
+
+  private:
+  librados::IoCtx* context;
+  std::list<ReadOpData> operations;
+};
 
 /// simple integer parsing, to be replaced by std::stoll when C++11 can be used
 static unsigned long long int stoull(const std::string &s) {
@@ -888,6 +961,87 @@ ssize_t ceph_aio_write(int fd, XrdSfsAio *aiop, AioCB *cb) {
     ::gettimeofday(&fr->lastAsyncSubmission, nullptr);
     fr->bytesAsyncWritePending+=count;
     return rc;
+  } else {
+    return -EBADF;
+  }
+}
+
+ssize_t ceph_async_read(int fd, void *buff, size_t blen, off_t offset)  {
+  CephFileRef* fr = getFileRef(fd);
+  if (fr) {
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
+    if ((fr->flags & O_WRONLY) != 0) {
+      return -EBADF;
+    }
+
+    const unsigned int block_size = fr->objectSize;
+
+    int rc;
+    ssize_t end_block, req_len, chunk_start, chunk_len, read_bytes;
+    size_t buf_pos;
+    unsigned int start_block;
+    char * fname;
+    char * buf_ptr;
+
+    req_len = blen;
+
+    try {
+      //Extra 18 symbols for stipe object -- 16 digits, dot and null
+      fname = new char[strlen(fr->name.c_str()) + 18];
+    } catch(std::bad_alloc&) {
+      logwrapper( (char*)"Can not allocate data for block filename\n");
+      return -ENOMEM;
+    }
+
+    librados::IoCtx *ioctx = getIoCtx(*fr);
+    if (0 == ioctx) {
+      logwrapper( (char*)"Can not ioctx context for readv\n");
+      return -EINVAL;
+    }
+    bulkAioRead readOp = bulkAioRead(ioctx);
+
+    start_block = offset / block_size;
+    end_block = (offset + req_len - 1) / block_size;
+    buf_ptr = (char*) buff;
+    buf_pos = 0;
+
+    while (start_block <= end_block) {
+      sprintf(fname, "%s.%016x", fr->name.c_str(), start_block);
+      chunk_start = offset % block_size;
+      if (req_len < block_size - chunk_start) {
+        chunk_len = req_len;
+      } else {
+        chunk_len = block_size - chunk_start;
+      }
+
+      //logwrapper((char*)"Going to read %s, %lu %lu\n", fname, chunk_len, chunk_start);
+      rc = readOp.addRequest(fname, chunk_len, chunk_start, buf_ptr);
+      if (rc < 0) {
+        logwrapper((char*)"Unable to submit async read request of file %s: rc=%d\n", fname, rc);
+        delete[] fname;
+        return rc;
+      }
+      buf_pos += chunk_len;
+      if (buf_pos > blen) {
+        logwrapper((char*)"Internal bug! Attempt to read %lu data for block (%lu, %lu)\n", buf_pos, offset, blen);
+        delete[] fname;
+        return -EINVAL;
+      }
+      buf_ptr += chunk_len;
+
+      start_block++;
+      offset = start_block*block_size;
+      req_len = req_len - chunk_len;
+    }
+
+    read_bytes = 0;
+    readOp.wait_for_complete();
+    read_bytes = readOp.get_results();
+    delete [] fname;
+    XrdSysMutexHelper lock(fr->statsMutex);
+    fr->rdcount += 1;
+    return read_bytes;
   } else {
     return -EBADF;
   }

--- a/src/XrdCeph/XrdCephPosix.hh
+++ b/src/XrdCeph/XrdCephPosix.hh
@@ -34,6 +34,7 @@
 #include <dirent.h>
 #include <XrdOuc/XrdOucEnv.hh>
 #include <XrdSys/XrdSysXAttr.hh>
+#include "XrdOuc/XrdOucIOVec.hh"
 
 class XrdSfsAio;
 typedef void(AioCB)(XrdSfsAio*, size_t);
@@ -48,6 +49,7 @@ off64_t ceph_posix_lseek64(int fd, off64_t offset, int whence);
 ssize_t ceph_posix_write(int fd, const void *buf, size_t count);
 ssize_t ceph_posix_pwrite(int fd, const void *buf, size_t count, off64_t offset);
 ssize_t ceph_aio_write(int fd, XrdSfsAio *aiop, AioCB *cb);
+ssize_t ceph_async_read(int fd, void *buff, size_t blen, off_t offset);
 ssize_t ceph_posix_read(int fd, void *buf, size_t count);
 ssize_t ceph_posix_pread(int fd, void *buf, size_t count, off64_t offset);
 ssize_t ceph_aio_read(int fd, XrdSfsAio *aiop, AioCB *cb);

--- a/src/XrdCeph/XrdCephPosix.hh
+++ b/src/XrdCeph/XrdCephPosix.hh
@@ -36,6 +36,9 @@
 #include <XrdSys/XrdSysXAttr.hh>
 #include "XrdOuc/XrdOucIOVec.hh"
 
+//if aio issued in ceph_async_read takes more then this (seconds), print warning
+#define XRDCEPH_AIO_WARN_THRESH 15
+
 class XrdSfsAio;
 typedef void(AioCB)(XrdSfsAio*, size_t);
 


### PR DESCRIPTION
Previous implementation of readv is the following: every readv request is executed as a sequence of synchronous read of indivitual chunks. It has poor performance, which affect significanlty vo operatoins, especially the LHCb ones.

To improve the situation we introduce several changes:
1. We use local buffering. The idea is to read huge pice of file and then extract requested chunks from this piece.
2. We do not use rados striper for the reads, but read data directly from ceph objects. This seem to improve performance significantly.
3. If a piece of file that should be read occupies multiple ceph objects, reads are executed asynchronously.