### PR TITLE
Buffered io multibuffers

### DIFF
--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -68,15 +68,18 @@ ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     //auto elapsed = end-start;
     auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end-start);
 
-    if (rc < 0) return rc;
+    if (rc < 0) {
+      BUFLOG("CephIOAdapterRaw::read: Error in read: " << rc );
+      return rc;
+    }
 
     m_stats_read_longest = std::max(m_stats_read_longest,int_ms.count()); 
     m_stats_read_timer.fetch_add(int_ms.count());
     m_stats_read_bytes.fetch_add(rc);
     ++m_stats_read_req;
 
-    // BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
-    //          << " " << count << " " << rc << " " << int_ms.count() );
+    BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
+             << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc>=0) {
       m_bufferdata->setLength(rc);

--- a/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
+++ b/src/XrdCeph/XrdCephBuffers/CephIOAdapterRaw.cc
@@ -78,8 +78,8 @@ ssize_t CephIOAdapterRaw::read(off64_t offset, size_t count) {
     m_stats_read_bytes.fetch_add(rc);
     ++m_stats_read_req;
 
-    BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
-             << " " << count << " " << rc << " " << int_ms.count() );
+    // BUFLOG("CephIOAdapterRaw::read fd:" << m_fd << " " << rc << " " << offset
+    //          << " " << count << " " << rc << " " << int_ms.count() );
 
     if (rc>=0) {
       m_bufferdata->setLength(rc);

--- a/src/XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh
+++ b/src/XrdCeph/XrdCephBuffers/IXrdCephReadVAdapter.hh
@@ -35,7 +35,7 @@ namespace XrdCephBuffer
          * @param extentsIn 
          * @return std::vector<ExtentHolder> 
          */
-        virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsIn) const  =0;
+        virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsIn)  =0;
 
     protected:
     };

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.cc
@@ -139,7 +139,7 @@ ssize_t XrdCephBufferAlgSimple::read(volatile void *buf,   off_t offset, size_t 
             // BUFLOG("XrdCephBufferAlgSimple::read: preLock: " << std::hash<std::thread::id>{}(std::this_thread::get_id()) << " " << "Filling the cache");
             m_bufferdata->invalidate();
             rc = m_cephio->read(offset + offsetDelta, m_bufferdata->capacity()); // fill the cache
-            BUFLOG("LoadCache ReadToCache: " << rc << " " << offset + offsetDelta << " " << m_bufferdata->capacity() );
+            // BUFLOG("LoadCache ReadToCache: " << rc << " " << offset + offsetDelta << " " << m_bufferdata->capacity() );
             if (rc < 0) {
                 BUFLOG("LoadCache Error: " << rc);
                 return rc;// TODO return correct errors

--- a/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephBufferAlgSimple.hh
@@ -54,6 +54,10 @@ class XrdCephBufferAlgSimple : public virtual  IXrdCephBufferAlg {
         size_t m_bufferLength = 0;
 
         std::recursive_mutex m_data_mutex; // any data access method on the buffer will use this
+
+        long m_stats_bytes_fromceph{0}; //! number of bytes requested from ceph, to fill the buffers, etc.
+        long m_stats_bytes_bypassed{0}; //! number of bytes specifically bypassed
+        long m_stats_bytes_toclient{0}; //! number of bytes requested by the client
 };  
 
 }

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVBasic.hh
@@ -26,13 +26,19 @@ namespace XrdCephBuffer
     // nothing more than readV in, and readV out
     public:
         XrdCephReadVBasic() {}
-        virtual ~XrdCephReadVBasic() {}
+        virtual ~XrdCephReadVBasic();
 
-    virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsHolderInput) const override;
+    virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsHolderInput) override;
 
     protected:
-        size_t m_minSize = 2*1024*1024;
-        size_t m_maxSize = 64*1024*1024;
+        ssize_t m_minSize = 2*1024*1024;
+        ssize_t m_maxSize = 16*1024*1024;
+
+    private:
+        size_t m_usedBytes = 0;
+        size_t m_wastedBytes = 0;
+        
+
     };
 
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.cc
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.cc
@@ -4,7 +4,7 @@
 
 using namespace XrdCephBuffer;
 
-std::vector<ExtentHolder> XrdCephReadVNoOp::convert(const ExtentHolder &extentsHolderInput) const
+std::vector<ExtentHolder> XrdCephReadVNoOp::convert(const ExtentHolder &extentsHolderInput)
 {
     std::vector<ExtentHolder> outputs;
 

--- a/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.hh
+++ b/src/XrdCeph/XrdCephBuffers/XrdCephReadVNoOp.hh
@@ -26,7 +26,7 @@ namespace XrdCephBuffer
         XrdCephReadVNoOp() {}
         virtual ~XrdCephReadVNoOp() {}
 
-    virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsHolderInput) const override;
+    virtual std::vector<ExtentHolder> convert(const ExtentHolder &extentsHolderInput) override;
 
     protected:
     };

--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -189,7 +189,23 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
            Eroute.Emsg("Config", "Missing value for ceph.buffersize in config file", configfn);
            return 1;
          }
-       } // usebuffer
+       } // buffersize
+        if (!strncmp(var, "ceph.buffermaxpersimul", 22)) { // size in bytes
+         var = Config.GetWord();
+         if (var) {
+           unsigned long value = strtoul(var, 0, 10);
+           if (value > 0 and value <= 1000000000L) {
+             m_configMaxSimulBufferCount = value;
+            Eroute.Emsg("Config", "ceph.buffermaxpersimul", std::to_string(m_configMaxSimulBufferCount).c_str() ); 
+           } else {
+             Eroute.Emsg("Config", "Invalid value for ceph.buffermaxpersimul in config file; enter in bytes (no units)", configfn, var);
+             return 1;
+           }
+         } else {
+           Eroute.Emsg("Config", "Missing value for ceph.buffermaxpersimul in config file", configfn);
+           return 1;
+         }
+       } // buffersize
 
           if (!strncmp(var, "ceph.usereadv", 13)) { // allowable values: 0, 1
          var = Config.GetWord();
@@ -358,7 +374,8 @@ XrdOssDF* XrdCephOss::newFile(const char *tident) {
   }
 
   if (m_configBufferEnable) {
-    xrdCephOssDF = new XrdCephOssBufferedFile(this,xrdCephOssDF, m_configBufferSize, m_configBufferIOmode);
+    xrdCephOssDF = new XrdCephOssBufferedFile(this,xrdCephOssDF, m_configBufferSize, 
+                                              m_configBufferIOmode, m_configMaxSimulBufferCount);
   }
 
 

--- a/src/XrdCeph/XrdCephOss.hh
+++ b/src/XrdCeph/XrdCephOss.hh
@@ -77,7 +77,8 @@ public:
     std::string m_configBufferIOmode = "aio";
     bool m_configReadVEnable=false; //! enable readV decorator
     std::string m_configReadVAlgName="passthrough"; // readV algorithm type
-    
+    size_t m_configMaxSimulBufferCount=10;  //! max number of buffers in a single Oss instance (.e.g simul. reads)
+
 };
 
 #endif /* __CEPH_OSS_HH__ */

--- a/src/XrdCeph/XrdCephOssBufferedFile.cc
+++ b/src/XrdCeph/XrdCephOssBufferedFile.cc
@@ -167,7 +167,7 @@ ssize_t XrdCephOssBufferedFile::Read(void *buff, off_t offset, size_t blen) {
         // if we can't create a buffer, we just have to pass through the read ... 
         ssize_t rc = m_xrdOssDF->Read(buff, offset, blen);
         if (rc >= 0) {
-          LOGCEPH( "XrdCephOssBufferedFile::Read buffers bypassed (too many simultaneous buffers, and read failed with rc: " << rc );
+          LOGCEPH( "XrdCephOssBufferedFile::Read buffers and read failed with rc: " << rc );
         }
         return rc;
       }

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -36,7 +36,8 @@
 #include <memory>
 #include <chrono>
 #include <atomic>
-
+#include <map>
+#include <mutex>
 
 //------------------------------------------------------------------------------
 //! Decorator class XrdCephOssBufferedFile designed to wrap XrdCephOssFile
@@ -68,6 +69,10 @@ protected:
   XrdCephOss *m_cephoss  = nullptr;
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
   std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg> m_bufferAlg;
+  std::map<size_t, std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg> > m_bufferReadAlgs;
+  std::mutex m_buf_mutex; // any data access method on the buffer will use this
+
+
 
   int m_maxBufferRetries {5}; //! How many times to retry a ready from a buffer with EBUSY errors 
   int m_maxBufferRetrySleepTime_ms; //! number of ms to sleep if a retry is requested 

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -66,6 +66,8 @@ public:
   virtual int Ftruncate(unsigned long long);
 
 protected:
+  std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg> createBuffer(); /// create a new instance of the buffer
+
   XrdCephOss *m_cephoss  = nullptr;
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
   std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg> m_bufferAlg;

--- a/src/XrdCeph/XrdCephOssBufferedFile.hh
+++ b/src/XrdCeph/XrdCephOssBufferedFile.hh
@@ -49,7 +49,8 @@ class XrdCephOssBufferedFile : virtual public XrdCephOssFile { // XrdOssDF
 
 public:
   XrdCephOssBufferedFile(XrdCephOss *cephoss,XrdCephOssFile *cephossDF, size_t buffersize, 
-                          const std::string& bufferIOmode); 
+                          const std::string& bufferIOmode,
+                          size_t maxNumberSimulBuffers); 
   //explicit XrdCephOssBufferedFile(size_t buffersize); 
   virtual ~XrdCephOssBufferedFile();
   virtual int Open(const char *path, int flags, mode_t mode, XrdOucEnv &env);
@@ -72,8 +73,8 @@ protected:
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
   std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg> m_bufferAlg;
   std::map<size_t, std::unique_ptr<XrdCephBuffer::IXrdCephBufferAlg> > m_bufferReadAlgs;
-  std::mutex m_buf_mutex; // any data access method on the buffer will use this
-
+  std::mutex m_buf_mutex; //! any data access method on the buffer will use this
+  size_t m_maxCountReadBuffers {10}; //! set the maximum of buffers to open on a single instance (e.g. for simultaneous file reads)
 
 
   int m_maxBufferRetries {5}; //! How many times to retry a ready from a buffer with EBUSY errors 

--- a/src/XrdCeph/XrdCephOssReadVFile.hh
+++ b/src/XrdCeph/XrdCephOssReadVFile.hh
@@ -76,6 +76,7 @@ public:
 protected:
   XrdCephOss *m_cephoss  = nullptr;
   XrdCephOssFile * m_xrdOssDF = nullptr; // holder of the XrdCephOssFile instance
+  bool m_extraLogging = true; // use verbose logging
   std::string m_algname = "passthrough";
   std::unique_ptr<XrdCephBuffer::IXrdCephReadVAdapter> m_readVAdapter;
 


### PR DESCRIPTION
Enable simultaneous reads from different clients access to their own buffers to improve the performance of file reads.

Fix issue where buffer might not retrieve more data from the storage, with smallish buffer sizes. 