### PR TITLE
Draft: Add locking

### DIFF
--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -46,7 +46,8 @@ add_library(
   XrdCeph/XrdCephOss.cc       XrdCeph/XrdCephOss.hh
   XrdCeph/XrdCephOssFile.cc   XrdCeph/XrdCephOssFile.hh
   XrdCeph/XrdCephOssDir.cc    XrdCeph/XrdCephOssDir.hh
-  XrdCeph/XrdCephBulkAioRead.cc XrdCeph/XrdCephBulkAioRead.hh)
+  XrdCeph/XrdCephBulkAioRead.cc XrdCeph/XrdCephBulkAioRead.hh
+  XrdCeph/XrdCephFileLock.cc XrdCeph/XrdCephFileLock.hh)
 
 target_link_libraries(
   ${LIB_XRD_CEPH}

--- a/src/XrdCeph/XrdCephFileLock.cc
+++ b/src/XrdCeph/XrdCephFileLock.cc
@@ -1,0 +1,44 @@
+#include "XrdCeph/XrdCephFileLock.hh"
+
+XrdCephFileLock::XrdCephFileLock(const CephFile file, librados::IoCtx* ctx) {
+  /**
+   * Constructor.
+   *
+   * @param file    ceph file description
+   *
+   */
+
+    fr = file;
+    obj_name = fr.name + lock_ext;
+
+    char host[128];
+    gethostname(host, MAX_HOST_NAME);
+    cookie = std::string(host);
+    ioctx = ctx; 
+}
+
+int XrdCephFileLock::acquire() {
+  /**
+   * Acquire the lock.
+   *
+   */
+
+    struct timeval lock_lifetime;
+    lock_lifetime.tv_sec = 3600*5;
+    lock_lifetime.tv_usec = 0;
+
+    int rc = ioctx->lock_exclusive(obj_name, XrdCeph_object_lock, cookie, "", &lock_lifetime, 0);
+    return rc;
+}
+
+int XrdCephFileLock::release() {
+  /**
+   * Release the lock.
+   *
+   */
+    int rc = ioctx->unlock(obj_name, XrdCeph_object_lock, cookie);
+    if (0 == rc) {
+       rc = ioctx->remove(obj_name);
+    }
+    return rc;
+}

--- a/src/XrdCeph/XrdCephFileLock.hh
+++ b/src/XrdCeph/XrdCephFileLock.hh
@@ -1,0 +1,30 @@
+#include <string>
+#include <rados/librados.hpp>
+
+#include "XrdCeph/XrdCephPosix.hh"
+
+#define MAX_HOST_NAME 128
+
+/**
+ * Lock or unlock a file using rados.
+ * Host name is used as lock cookie.
+ * A separate object named <filename>.XrdCeph_Exclusive_lock is for locking (to prevent issues with striper)
+ * Can be useful to prevent simultaneous writes/deletes of the same file.
+ *
+ */
+
+
+
+struct XrdCephFileLock {
+  const std::string lock_ext = std::string(".XrdCeph_Exlcusive_lock");
+  //const std::string lock_ext = std::string(".0000000000000000");
+  const std::string XrdCeph_object_lock = "xrdceph.lock";
+  CephFile fr;
+  std::string obj_name;
+  std::string cookie;
+  librados::IoCtx* ioctx;
+
+  XrdCephFileLock(const CephFile file,  librados::IoCtx*);
+  int acquire();
+  int release();
+};

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -617,52 +617,6 @@ void ceph_posix_set_logfunc(void (*logfunc) (char *, va_list argp)) {
 
 static int ceph_posix_internal_truncate(const CephFile &file, unsigned long long size);
 
-/*
-
-struct XrdCephFileLock {
-  const std::string lock_ext = std::string(".XrdCeph_Exlcusive_lock");
-  CephFile fr;
-  std::string obj_name;
-  std::string cookie;
-
-  XrdCephFileLock(const CephFile file) {
-
-    fr = file;
-    obj_name = fr.name + lock_ext;
-
-    char host[128];
-    gethostname(host, MAX_HOST_NAME);
-    cookie = std::string(host);  
-  }
-
-  int acquire() {
-
-    librados::IoCtx *ioctx = getIoCtx(fr);
-    if (0 == ioctx) {
-      return -EINVAL;
-    }
-
-    struct timeval lock_lifetime;
-    lock_lifetime.tv_sec = 3600*5;
-    lock_lifetime.tv_usec = 0;
-
-    int rc = ioctx->lock_exclusive(obj_name, XrdCeph_object_lock, cookie, "", &lock_lifetime, 0);
-    return rc;
-  }
-
-  int release() {
-    librados::IoCtx *ioctx = getIoCtx(fr);
-    if (0 == ioctx) {
-      return -EINVAL;
-    }
-
-    int rc = ioctx->remove(obj_name);
-
-    return rc;
-  }
-};
-*/
-
 /**
  * * brief ceph_posix_open function opens a file for read or write
  * * details This function either:


### PR DESCRIPTION
This might be useful to prevent data loss/corruption when we have simultaneous transfers of the same file.

We do the locking in the following way: lock is added to a separate object with the name <file_name>.<lock_name>, where <lock_name> is different from file's object numbers (it is basically a text string). On lock release, this object is removed. We use this ugly technique instead of locking the first object for the following reason: radosstriper does not like when it tries to create a new file and its first object already exists.